### PR TITLE
feat: add -C directory flag

### DIFF
--- a/cmd/gwt/main_test.go
+++ b/cmd/gwt/main_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveDirectory(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EmptyDirFlag", func(t *testing.T) {
+		t.Parallel()
+
+		baseCwd := "/some/path"
+		got, err := resolveDirectory("", baseCwd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != baseCwd {
+			t.Errorf("got %q, want %q", got, baseCwd)
+		}
+	})
+
+	t.Run("NonexistentPath", func(t *testing.T) {
+		t.Parallel()
+
+		baseCwd := t.TempDir()
+		_, err := resolveDirectory("/nonexistent/path", baseCwd)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot change to '/nonexistent/path'") {
+			t.Errorf("error %q should contain path", err.Error())
+		}
+	})
+
+	t.Run("PathIsFile", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "file.txt")
+		if err := os.WriteFile(filePath, []byte("content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := resolveDirectory(filePath, tmpDir)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "not a directory") {
+			t.Errorf("error %q should contain 'not a directory'", err.Error())
+		}
+	})
+
+	t.Run("ValidAbsolutePath", func(t *testing.T) {
+		t.Parallel()
+
+		targetDir := t.TempDir()
+		baseCwd := t.TempDir()
+
+		got, err := resolveDirectory(targetDir, baseCwd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Resolve symlinks for comparison (macOS /var -> /private/var)
+		want, _ := filepath.EvalSymlinks(targetDir)
+		gotResolved, _ := filepath.EvalSymlinks(got)
+		if gotResolved != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("ValidRelativePath", func(t *testing.T) {
+		t.Parallel()
+
+		baseCwd := t.TempDir()
+		subDir := filepath.Join(baseCwd, "subdir")
+		if err := os.Mkdir(subDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := resolveDirectory("subdir", baseCwd)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		want, _ := filepath.EvalSymlinks(subDir)
+		gotResolved, _ := filepath.EvalSymlinks(got)
+		if gotResolved != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add `-C, --directory` persistent flag to run gwt as if started in the specified directory
- Similar to git's `-C` option
- Supports both absolute and relative paths
- Validates that the specified path exists and is a directory
- Extract `resolveDirectory` function for testability

## Test plan

- [x] Build succeeds
- [x] Unit tests pass
  - [x] Empty dirFlag returns baseCwd unchanged
  - [x] Nonexistent path returns error
  - [x] File path (not directory) returns error
  - [x] Valid absolute path resolves correctly
  - [x] Valid relative path resolves correctly
- [x] Manual testing with `--dry-run`:
  - [x] Error case: nonexistent path
  - [x] Error case: path is a file (not directory)
  - [x] Success: absolute path to different repo