### PR TITLE
ci: add GitHub Actions workflow for integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.25.5"
+          cache: true
 
       - name: Run integration tests
         run: go test -tags=integration ./...


### PR DESCRIPTION
## Summary

- mainブランチへのPRで発火するGitHub Actionsワークフローを追加
- integration tests (`go test -tags=integration ./...`) を実行

## Test plan

- [x] PRを作成してワークフローが発火することを確認
- [x] integration testsが正常に実行されることを確認