### PR TITLE
refactor: introduce Result types for structured command output

### DIFF
--- a/cmd/gwt/main.go
+++ b/cmd/gwt/main.go
@@ -99,7 +99,19 @@ var addCmd = &cobra.Command{
 		return branches, cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return gwt.NewAddCommand(cfg).Run(args[0])
+		verbose, _ := cmd.Flags().GetBool("verbose")
+
+		result, err := gwt.NewAddCommand(cfg).Run(args[0])
+		if err != nil {
+			return err
+		}
+
+		formatted := result.Format(gwt.FormatOptions{Verbose: verbose})
+		if formatted.Stderr != "" {
+			fmt.Fprint(os.Stderr, formatted.Stderr)
+		}
+		fmt.Fprint(os.Stdout, formatted.Stdout)
+		return nil
 	},
 }
 
@@ -128,18 +140,30 @@ Use --force to override these checks.`,
 		return branches, cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		verbose, _ := cmd.Flags().GetBool("verbose")
 		force, _ := cmd.Flags().GetBool("force")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 
-		return gwt.NewRemoveCommand(cfg).Run(args[0], cwd, gwt.RemoveOptions{
+		result, err := gwt.NewRemoveCommand(cfg).Run(args[0], cwd, gwt.RemoveOptions{
 			Force:  force,
 			DryRun: dryRun,
 		})
+		if err != nil {
+			return err
+		}
+
+		formatted := result.Format(gwt.FormatOptions{Verbose: verbose})
+		if formatted.Stderr != "" {
+			fmt.Fprint(os.Stderr, formatted.Stderr)
+		}
+		fmt.Fprint(os.Stdout, formatted.Stdout)
+		return nil
 	},
 }
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&dirFlag, "directory", "C", "", "Run as if gwt was started in <path>")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
 	rootCmd.AddCommand(addCmd)
 
 	removeCmd.Flags().BoolP("force", "f", false, "Force removal even with uncommitted changes or unmerged branch")

--- a/git_integration_test.go
+++ b/git_integration_test.go
@@ -3,7 +3,6 @@
 package gwt
 
 import (
-	"bytes"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,8 +21,7 @@ func TestGitRunner_WorktreeFindByBranch_Integration(t *testing.T) {
 		wtPath := filepath.Join(repoDir, "feature-wt")
 		testutil.RunGit(t, mainDir, "worktree", "add", wtPath, "-b", "feature/test")
 
-		var stdout bytes.Buffer
-		runner := newTestGitRunner(mainDir, &stdout)
+		runner := NewGitRunner(mainDir)
 
 		got, err := runner.WorktreeFindByBranch("feature/test")
 		if err != nil {
@@ -39,8 +37,7 @@ func TestGitRunner_WorktreeFindByBranch_Integration(t *testing.T) {
 
 		_, mainDir := testutil.SetupTestRepo(t)
 
-		var stdout bytes.Buffer
-		runner := newTestGitRunner(mainDir, &stdout)
+		runner := NewGitRunner(mainDir)
 
 		_, err := runner.WorktreeFindByBranch("nonexistent")
 		if err == nil {
@@ -63,10 +60,9 @@ func TestGitRunner_WorktreeRemove_Integration(t *testing.T) {
 		wtPath := filepath.Join(repoDir, "to-remove")
 		testutil.RunGit(t, mainDir, "worktree", "add", wtPath, "-b", "to-remove")
 
-		var stdout bytes.Buffer
-		runner := newTestGitRunner(mainDir, &stdout)
+		runner := NewGitRunner(mainDir)
 
-		err := runner.WorktreeRemove(wtPath)
+		_, err := runner.WorktreeRemove(wtPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -82,10 +78,9 @@ func TestGitRunner_WorktreeRemove_Integration(t *testing.T) {
 
 		_, mainDir := testutil.SetupTestRepo(t)
 
-		var stdout bytes.Buffer
-		runner := newTestGitRunner(mainDir, &stdout)
+		runner := NewGitRunner(mainDir)
 
-		err := runner.WorktreeRemove("/nonexistent/path")
+		_, err := runner.WorktreeRemove("/nonexistent/path")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -105,10 +100,9 @@ func TestGitRunner_BranchDelete_Integration(t *testing.T) {
 
 		testutil.RunGit(t, mainDir, "branch", "to-delete")
 
-		var stdout bytes.Buffer
-		runner := newTestGitRunner(mainDir, &stdout)
+		runner := NewGitRunner(mainDir)
 
-		err := runner.BranchDelete("to-delete")
+		_, err := runner.BranchDelete("to-delete")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -128,10 +122,9 @@ func TestGitRunner_BranchDelete_Integration(t *testing.T) {
 		testutil.RunGit(t, mainDir, "commit", "--allow-empty", "-m", "unmerged commit")
 		testutil.RunGit(t, mainDir, "checkout", "main")
 
-		var stdout bytes.Buffer
-		runner := newTestGitRunner(mainDir, &stdout)
+		runner := NewGitRunner(mainDir)
 
-		err := runner.BranchDelete("unmerged", WithForceDelete())
+		_, err := runner.BranchDelete("unmerged", WithForceDelete())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -147,10 +140,9 @@ func TestGitRunner_BranchDelete_Integration(t *testing.T) {
 
 		_, mainDir := testutil.SetupTestRepo(t)
 
-		var stdout bytes.Buffer
-		runner := newTestGitRunner(mainDir, &stdout)
+		runner := NewGitRunner(mainDir)
 
-		err := runner.BranchDelete("nonexistent")
+		_, err := runner.BranchDelete("nonexistent")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}

--- a/remove.go
+++ b/remove.go
@@ -2,8 +2,6 @@ package gwt
 
 import (
 	"fmt"
-	"io"
-	"os"
 	"strings"
 )
 
@@ -12,8 +10,6 @@ type RemoveCommand struct {
 	FS     FileSystem
 	Git    *GitRunner
 	Config *Config
-	Stdout io.Writer
-	Stderr io.Writer
 }
 
 // RemoveOptions configures the remove operation.
@@ -28,52 +24,88 @@ func NewRemoveCommand(cfg *Config) *RemoveCommand {
 		FS:     osFS{},
 		Git:    NewGitRunner(cfg.WorktreeSourceDir),
 		Config: cfg,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
 	}
+}
+
+// RemoveResult holds the result of a remove operation.
+type RemoveResult struct {
+	Branch       string
+	WorktreePath string
+	DryRun       bool
+	GitOutput    []byte
+}
+
+// Format formats the RemoveResult for display.
+func (r RemoveResult) Format(opts FormatOptions) FormatResult {
+	var stdout strings.Builder
+
+	if r.DryRun {
+		stdout.WriteString(fmt.Sprintf("Would remove worktree: %s\n", r.WorktreePath))
+		stdout.WriteString(fmt.Sprintf("Would delete branch: %s\n", r.Branch))
+		return FormatResult{Stdout: stdout.String()}
+	}
+
+	if opts.Verbose {
+		if len(r.GitOutput) > 0 {
+			stdout.Write(r.GitOutput)
+		}
+		stdout.WriteString(fmt.Sprintf("Removed worktree and branch: %s\n", r.Branch))
+	}
+
+	stdout.WriteString(fmt.Sprintf("gwt remove: %s\n", r.Branch))
+
+	return FormatResult{Stdout: stdout.String()}
 }
 
 // Run removes the worktree and branch for the given branch name.
 // cwd is the current working directory (absolute path) passed from CLI layer.
-func (c *RemoveCommand) Run(branch string, cwd string, opts RemoveOptions) error {
+func (c *RemoveCommand) Run(branch string, cwd string, opts RemoveOptions) (RemoveResult, error) {
+	var result RemoveResult
+	result.Branch = branch
+	result.DryRun = opts.DryRun
+
 	if branch == "" {
-		return fmt.Errorf("branch name is required")
+		return result, fmt.Errorf("branch name is required")
 	}
 	if c.Config.WorktreeSourceDir == "" {
-		return fmt.Errorf("worktree source directory is not configured")
+		return result, fmt.Errorf("worktree source directory is not configured")
 	}
 
 	wtPath, err := c.Git.WorktreeFindByBranch(branch)
 	if err != nil {
-		return err
+		return result, err
 	}
+	result.WorktreePath = wtPath
 
 	if strings.HasPrefix(cwd, wtPath) {
-		return fmt.Errorf("cannot remove: current directory is inside worktree %s", wtPath)
+		return result, fmt.Errorf("cannot remove: current directory is inside worktree %s", wtPath)
 	}
 
 	if opts.DryRun {
-		fmt.Fprintf(c.Stdout, "Would remove worktree: %s\n", wtPath)
-		fmt.Fprintf(c.Stdout, "Would delete branch: %s\n", branch)
-		return nil
+		return result, nil
 	}
 
+	var gitOutput []byte
 	var wtOpts []WorktreeRemoveOption
 	if opts.Force {
 		wtOpts = append(wtOpts, WithForceRemove())
 	}
-	if err := c.Git.WorktreeRemove(wtPath, wtOpts...); err != nil {
-		return err
+	wtOut, err := c.Git.WorktreeRemove(wtPath, wtOpts...)
+	if err != nil {
+		return result, err
 	}
+	gitOutput = append(gitOutput, wtOut...)
 
 	var branchOpts []BranchDeleteOption
 	if opts.Force {
 		branchOpts = append(branchOpts, WithForceDelete())
 	}
-	if err := c.Git.BranchDelete(branch, branchOpts...); err != nil {
-		return err
+	brOut, err := c.Git.BranchDelete(branch, branchOpts...)
+	if err != nil {
+		return result, err
 	}
+	gitOutput = append(gitOutput, brOut...)
 
-	fmt.Fprintf(c.Stdout, "Removed worktree and branch: %s\n", branch)
-	return nil
+	result.GitOutput = gitOutput
+	return result, nil
 }

--- a/remove_integration_test.go
+++ b/remove_integration_test.go
@@ -3,7 +3,6 @@
 package gwt
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,16 +45,13 @@ worktree_destination_base_dir = %q
 			t.Fatal(err)
 		}
 
-		var stdout, stderr bytes.Buffer
 		cmd := &RemoveCommand{
 			FS:     osFS{},
-			Git:    newTestGitRunner(mainDir, &stdout),
+			Git:    NewGitRunner(mainDir),
 			Config: result.Config,
-			Stdout: &stdout,
-			Stderr: &stderr,
 		}
 
-		err = cmd.Run("feature/to-remove", mainDir, RemoveOptions{})
+		removeResult, err := cmd.Run("feature/to-remove", mainDir, RemoveOptions{})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
 		}
@@ -69,8 +65,9 @@ worktree_destination_base_dir = %q
 			t.Errorf("branch should be deleted, got: %s", out)
 		}
 
-		if !strings.Contains(stdout.String(), "Removed worktree and branch") {
-			t.Errorf("expected success message, got: %s", stdout.String())
+		// Verify result
+		if removeResult.Branch != "feature/to-remove" {
+			t.Errorf("result.Branch = %q, want %q", removeResult.Branch, "feature/to-remove")
 		}
 	})
 
@@ -99,16 +96,13 @@ worktree_destination_base_dir = %q
 			t.Fatal(err)
 		}
 
-		var stdout, stderr bytes.Buffer
 		cmd := &RemoveCommand{
 			FS:     osFS{},
-			Git:    newTestGitRunner(mainDir, &stdout),
+			Git:    NewGitRunner(mainDir),
 			Config: result.Config,
-			Stdout: &stdout,
-			Stderr: &stderr,
 		}
 
-		err = cmd.Run("feature/dry-run-test", mainDir, RemoveOptions{DryRun: true})
+		removeResult, err := cmd.Run("feature/dry-run-test", mainDir, RemoveOptions{DryRun: true})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
 		}
@@ -122,12 +116,9 @@ worktree_destination_base_dir = %q
 			t.Errorf("branch should still exist in dry-run mode")
 		}
 
-		stdoutStr := stdout.String()
-		if !strings.Contains(stdoutStr, "Would remove worktree") {
-			t.Errorf("expected dry-run message, got: %s", stdoutStr)
-		}
-		if !strings.Contains(stdoutStr, "Would delete branch") {
-			t.Errorf("expected dry-run branch message, got: %s", stdoutStr)
+		// Verify result
+		if !removeResult.DryRun {
+			t.Error("result.DryRun should be true")
 		}
 	})
 
@@ -161,16 +152,13 @@ worktree_destination_base_dir = %q
 			t.Fatal(err)
 		}
 
-		var stdout, stderr bytes.Buffer
 		cmd := &RemoveCommand{
 			FS:     osFS{},
-			Git:    newTestGitRunner(mainDir, &stdout),
+			Git:    NewGitRunner(mainDir),
 			Config: result.Config,
-			Stdout: &stdout,
-			Stderr: &stderr,
 		}
 
-		err = cmd.Run("feature/force-test", mainDir, RemoveOptions{Force: true})
+		_, err = cmd.Run("feature/force-test", mainDir, RemoveOptions{Force: true})
 		if err != nil {
 			t.Fatalf("Run with force failed: %v", err)
 		}
@@ -205,16 +193,13 @@ worktree_destination_base_dir = %q
 			t.Fatal(err)
 		}
 
-		var stdout, stderr bytes.Buffer
 		cmd := &RemoveCommand{
 			FS:     osFS{},
-			Git:    newTestGitRunner(mainDir, &stdout),
+			Git:    NewGitRunner(mainDir),
 			Config: result.Config,
-			Stdout: &stdout,
-			Stderr: &stderr,
 		}
 
-		err = cmd.Run("feature/inside-test", wtPath, RemoveOptions{})
+		_, err = cmd.Run("feature/inside-test", wtPath, RemoveOptions{})
 		if err == nil {
 			t.Fatal("expected error when inside worktree, got nil")
 		}
@@ -246,16 +231,13 @@ worktree_destination_base_dir = %q
 			t.Fatal(err)
 		}
 
-		var stdout, stderr bytes.Buffer
 		cmd := &RemoveCommand{
 			FS:     osFS{},
-			Git:    newTestGitRunner(mainDir, &stdout),
+			Git:    NewGitRunner(mainDir),
 			Config: result.Config,
-			Stdout: &stdout,
-			Stderr: &stderr,
 		}
 
-		err = cmd.Run("orphan-branch", mainDir, RemoveOptions{})
+		_, err = cmd.Run("orphan-branch", mainDir, RemoveOptions{})
 		if err == nil {
 			t.Fatal("expected error for branch not in worktree, got nil")
 		}

--- a/result.go
+++ b/result.go
@@ -1,0 +1,17 @@
+package gwt
+
+// FormatOptions configures output formatting.
+type FormatOptions struct {
+	Verbose bool
+}
+
+// FormatResult holds formatted output strings.
+type FormatResult struct {
+	Stdout string
+	Stderr string
+}
+
+// Formatter formats command results.
+type Formatter interface {
+	Format(opts FormatOptions) FormatResult
+}


### PR DESCRIPTION
## Summary

- コマンドの出力を構造化するため `AddResult` / `RemoveResult` 型を導入
- グローバル `--verbose` / `-v` フラグを追加し、詳細出力をオプション化
- `GitRunner` および各コマンドから `Stdout` / `Stderr` フィールドを削除し、出力責務をCLI層に移動

## Test plan

- [x] `go test ./...` passed
- [x] `make build` passed