### PR TITLE
feat: add list subcommand for worktree listing

### DIFF
--- a/.claude/rules/commands/list.md
+++ b/.claude/rules/commands/list.md
@@ -1,0 +1,49 @@
+# list subcommand
+
+List all worktrees.
+
+## Usage
+
+```txt
+gwt list [flags]
+```
+
+## Flags
+
+| Flag     | Short | Description                              |
+|----------|-------|------------------------------------------|
+| `--path` | `-p`  | Show full paths instead of branch names  |
+
+## Behavior
+
+- Lists all worktrees including the main worktree
+- Default output shows branch names only
+- With `--path`: shows full filesystem paths
+
+## Examples
+
+```txt
+# List branch names
+gwt list
+main
+feat/add-list-command
+feat/add-move-command
+
+# List full paths (for cd integration)
+gwt list --path
+/Users/user/repo
+/Users/user/repo-worktree/feat/add-list-command
+/Users/user/repo-worktree/feat/add-move-command
+```
+
+## Shell Integration
+
+Combine with fzf for quick worktree navigation:
+
+```bash
+gcd() {
+  local selected
+  selected=$(gwt list --path | fzf +m) &&
+  cd "$selected"
+}
+```

--- a/cmd/gwt/main.go
+++ b/cmd/gwt/main.go
@@ -116,6 +116,24 @@ var addCmd = &cobra.Command{
 	},
 }
 
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all worktrees",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		showPath, _ := cmd.Flags().GetBool("path")
+
+		result, err := gwt.NewListCommand(cwd).Run()
+		if err != nil {
+			return err
+		}
+
+		formatted := result.Format(gwt.ListFormatOptions{ShowPath: showPath})
+		fmt.Fprint(os.Stdout, formatted.Stdout)
+		return nil
+	},
+}
+
 var removeCmd = &cobra.Command{
 	Use:   "remove <branch>...",
 	Short: "Remove worktrees and their branches",
@@ -184,6 +202,9 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&dirFlag, "directory", "C", "", "Run as if gwt was started in <path>")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
 	rootCmd.AddCommand(addCmd)
+
+	listCmd.Flags().BoolP("path", "p", false, "Show full paths instead of branch names")
+	rootCmd.AddCommand(listCmd)
 
 	removeCmd.Flags().BoolP("force", "f", false, "Force removal even with uncommitted changes or unmerged branch")
 	removeCmd.Flags().Bool("dry-run", false, "Show what would be removed without making changes")

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -1,0 +1,49 @@
+# list subcommand
+
+List all worktrees.
+
+## Usage
+
+```txt
+gwt list [flags]
+```
+
+## Flags
+
+| Flag     | Short | Description                              |
+|----------|-------|------------------------------------------|
+| `--path` | `-p`  | Show full paths instead of branch names  |
+
+## Behavior
+
+- Lists all worktrees including the main worktree
+- Default output shows branch names only
+- With `--path`: shows full filesystem paths
+
+## Examples
+
+```txt
+# List branch names
+gwt list
+main
+feat/add-list-command
+feat/add-move-command
+
+# List full paths (for cd integration)
+gwt list --path
+/Users/user/repo
+/Users/user/repo-worktree/feat/add-list-command
+/Users/user/repo-worktree/feat/add-move-command
+```
+
+## Shell Integration
+
+Combine with fzf for quick worktree navigation:
+
+```bash
+gcd() {
+  local selected
+  selected=$(gwt list --path | fzf +m) &&
+  cd "$selected"
+}
+```

--- a/git.go
+++ b/git.go
@@ -82,6 +82,40 @@ func (g *GitRunner) BranchList() ([]string, error) {
 	return branches, nil
 }
 
+// WorktreeInfo holds worktree path and branch information.
+type WorktreeInfo struct {
+	Path   string
+	Branch string
+}
+
+// WorktreeList returns all worktrees with their paths and branches.
+func (g *GitRunner) WorktreeList() ([]WorktreeInfo, error) {
+	out, err := g.worktreeListPorcelain()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list worktrees: %w", err)
+	}
+
+	// porcelain format:
+	// worktree /path/to/worktree
+	// HEAD abc123
+	// branch refs/heads/branch-name
+	// (blank line)
+
+	var worktrees []WorktreeInfo
+	var current WorktreeInfo
+	for _, line := range strings.Split(string(out), "\n") {
+		if path, ok := strings.CutPrefix(line, "worktree "); ok {
+			current = WorktreeInfo{Path: path}
+		} else if branch, ok := strings.CutPrefix(line, "branch refs/heads/"); ok {
+			current.Branch = branch
+		} else if line == "" && current.Path != "" {
+			worktrees = append(worktrees, current)
+			current = WorktreeInfo{}
+		}
+	}
+	return worktrees, nil
+}
+
 // WorktreeListBranches returns a list of branch names currently checked out in worktrees.
 func (g *GitRunner) WorktreeListBranches() ([]string, error) {
 	output, err := g.worktreeListPorcelain()

--- a/list.go
+++ b/list.go
@@ -1,0 +1,53 @@
+package gwt
+
+import (
+	"strings"
+)
+
+// ListCommand lists all worktrees.
+type ListCommand struct {
+	Git *GitRunner
+}
+
+// NewListCommand creates a new ListCommand.
+func NewListCommand(dir string) *ListCommand {
+	return &ListCommand{
+		Git: NewGitRunner(dir),
+	}
+}
+
+// ListResult holds the result of a list operation.
+type ListResult struct {
+	Worktrees []WorktreeInfo
+}
+
+// ListFormatOptions configures list output formatting.
+type ListFormatOptions struct {
+	ShowPath bool
+}
+
+// Format formats the ListResult for display.
+func (r ListResult) Format(opts ListFormatOptions) FormatResult {
+	var stdout strings.Builder
+
+	for _, wt := range r.Worktrees {
+		if opts.ShowPath {
+			stdout.WriteString(wt.Path)
+		} else {
+			stdout.WriteString(wt.Branch)
+		}
+		stdout.WriteString("\n")
+	}
+
+	return FormatResult{Stdout: stdout.String()}
+}
+
+// Run lists all worktrees.
+func (c *ListCommand) Run() (ListResult, error) {
+	worktrees, err := c.Git.WorktreeList()
+	if err != nil {
+		return ListResult{}, err
+	}
+
+	return ListResult{Worktrees: worktrees}, nil
+}

--- a/list_integration_test.go
+++ b/list_integration_test.go
@@ -1,0 +1,109 @@
+//go:build integration
+
+package gwt
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/708u/gwt/internal/testutil"
+)
+
+func TestListCommand_Integration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ListsAllWorktrees", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		// Create additional worktrees
+		wtPathA := filepath.Join(repoDir, "feature", "a")
+		wtPathB := filepath.Join(repoDir, "feature", "b")
+		testutil.RunGit(t, mainDir, "worktree", "add", "-b", "feature/a", wtPathA)
+		testutil.RunGit(t, mainDir, "worktree", "add", "-b", "feature/b", wtPathB)
+
+		cmd := NewListCommand(mainDir)
+		result, err := cmd.Run()
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		// Should have 3 worktrees: main + 2 feature branches
+		if len(result.Worktrees) != 3 {
+			t.Errorf("expected 3 worktrees, got %d", len(result.Worktrees))
+		}
+
+		// Verify main worktree is included
+		var branches []string
+		for _, wt := range result.Worktrees {
+			branches = append(branches, wt.Branch)
+		}
+
+		if !slices.Contains(branches, "main") {
+			t.Error("main worktree should be included")
+		}
+		if !slices.Contains(branches, "feature/a") {
+			t.Error("feature/a worktree should be included")
+		}
+		if !slices.Contains(branches, "feature/b") {
+			t.Error("feature/b worktree should be included")
+		}
+	})
+
+	t.Run("ListsSingleWorktree", func(t *testing.T) {
+		t.Parallel()
+
+		_, mainDir := testutil.SetupTestRepo(t)
+
+		cmd := NewListCommand(mainDir)
+		result, err := cmd.Run()
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		// Should have only the main worktree
+		if len(result.Worktrees) != 1 {
+			t.Errorf("expected 1 worktree, got %d", len(result.Worktrees))
+		}
+
+		if result.Worktrees[0].Branch != "main" {
+			t.Errorf("expected main branch, got %q", result.Worktrees[0].Branch)
+		}
+
+		if result.Worktrees[0].Path != mainDir {
+			t.Errorf("expected path %q, got %q", mainDir, result.Worktrees[0].Path)
+		}
+	})
+
+	t.Run("FormatWithPath", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		wtPath := filepath.Join(repoDir, "feature", "test")
+		testutil.RunGit(t, mainDir, "worktree", "add", "-b", "feature/test", wtPath)
+
+		cmd := NewListCommand(mainDir)
+		result, err := cmd.Run()
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		// Format with path
+		formatted := result.Format(ListFormatOptions{ShowPath: true})
+
+		// Should contain full paths
+		if formatted.Stdout == "" {
+			t.Error("formatted output should not be empty")
+		}
+
+		// Verify paths are absolute
+		for _, wt := range result.Worktrees {
+			if !filepath.IsAbs(wt.Path) {
+				t.Errorf("path should be absolute: %s", wt.Path)
+			}
+		}
+	})
+}

--- a/list_test.go
+++ b/list_test.go
@@ -1,0 +1,128 @@
+package gwt
+
+import (
+	"testing"
+
+	"github.com/708u/gwt/internal/testutil"
+)
+
+func TestListCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		worktrees  []testutil.MockWorktree
+		wantCount  int
+		wantErr    bool
+	}{
+		{
+			name: "multiple worktrees",
+			worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main"},
+				{Path: "/repo/worktree/feat-a", Branch: "feat/a"},
+				{Path: "/repo/worktree/feat-b", Branch: "feat/b"},
+			},
+			wantCount: 3,
+		},
+		{
+			name: "single worktree",
+			worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main"},
+			},
+			wantCount: 1,
+		},
+		{
+			name:      "empty worktrees",
+			worktrees: []testutil.MockWorktree{},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &testutil.MockGitExecutor{
+				Worktrees: tt.worktrees,
+			}
+			cmd := &ListCommand{
+				Git: &GitRunner{Executor: mock},
+			}
+
+			result, err := cmd.Run()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(result.Worktrees) != tt.wantCount {
+				t.Errorf("got %d worktrees, want %d", len(result.Worktrees), tt.wantCount)
+			}
+
+			for i, wt := range result.Worktrees {
+				if wt.Path != tt.worktrees[i].Path {
+					t.Errorf("worktree[%d].Path = %q, want %q", i, wt.Path, tt.worktrees[i].Path)
+				}
+				if wt.Branch != tt.worktrees[i].Branch {
+					t.Errorf("worktree[%d].Branch = %q, want %q", i, wt.Branch, tt.worktrees[i].Branch)
+				}
+			}
+		})
+	}
+}
+
+func TestListResult_Format(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		worktrees  []WorktreeInfo
+		opts       ListFormatOptions
+		wantStdout string
+	}{
+		{
+			name: "default shows branch names",
+			worktrees: []WorktreeInfo{
+				{Path: "/repo/main", Branch: "main"},
+				{Path: "/repo/worktree/feat-a", Branch: "feat/a"},
+			},
+			opts:       ListFormatOptions{ShowPath: false},
+			wantStdout: "main\nfeat/a\n",
+		},
+		{
+			name: "with path shows full paths",
+			worktrees: []WorktreeInfo{
+				{Path: "/repo/main", Branch: "main"},
+				{Path: "/repo/worktree/feat-a", Branch: "feat/a"},
+			},
+			opts:       ListFormatOptions{ShowPath: true},
+			wantStdout: "/repo/main\n/repo/worktree/feat-a\n",
+		},
+		{
+			name:       "empty list",
+			worktrees:  []WorktreeInfo{},
+			opts:       ListFormatOptions{ShowPath: false},
+			wantStdout: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := ListResult{Worktrees: tt.worktrees}
+			formatted := result.Format(tt.opts)
+
+			if formatted.Stdout != tt.wantStdout {
+				t.Errorf("Stdout = %q, want %q", formatted.Stdout, tt.wantStdout)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add `gwt list` command to display all worktrees.

- Default output shows branch names only
- `--path` / `-p` flag shows full filesystem paths for shell integration (e.g., fzf + cd)

## Changes

- Add `WorktreeList()` method to `GitRunner` in `git.go`
- Add `ListCommand`, `ListResult`, `ListFormatOptions` in `list.go`
- Add unit tests in `list_test.go`
- Add integration tests in `list_integration_test.go`
- Register `listCmd` in `cmd/gwt/main.go`
- Add documentation in `docs/commands/list.md`

## Usage

```bash
# List branch names
gwt list
main
feat/add-list-command

# List full paths (for shell integration)
gwt list --path
/Users/user/repo
/Users/user/repo-worktree/feat/add-list-command
```

## Shell Integration Example

```bash
gcd() {
  local selected
  selected=$(gwt list --path | fzf +m) &&
  cd "$selected"
}
```

## Test Plan

- [x] Unit tests pass (`go test ./...`)
- [x] Integration tests pass (`go test -tags=integration ./...`)
- [x] Manual testing with `gwt list` and `gwt list --path`