### PR TITLE
feat(add): add --print flag for machine-readable output

### DIFF
--- a/add.go
+++ b/add.go
@@ -47,8 +47,50 @@ type AddResult struct {
 	ChangesSynced bool
 }
 
+// AddFormatOptions configures add output formatting.
+type AddFormatOptions struct {
+	Verbose bool
+	Print   []string // ["path"], ["path", "branch"], or empty for default
+}
+
+// ValidPrintFields contains valid --print field names.
+var ValidPrintFields = []string{"path"}
+
+// ValidatePrintFields validates the given print fields.
+func ValidatePrintFields(fields []string) error {
+	for _, f := range fields {
+		if !slices.Contains(ValidPrintFields, f) {
+			return fmt.Errorf("invalid print field: %s (valid: %s)",
+				f, strings.Join(ValidPrintFields, ", "))
+		}
+	}
+	return nil
+}
+
 // Format formats the AddResult for display.
-func (r AddResult) Format(opts FormatOptions) FormatResult {
+func (r AddResult) Format(opts AddFormatOptions) FormatResult {
+	// Print overrides default output
+	if len(opts.Print) > 0 {
+		return r.formatPrint(opts.Print)
+	}
+	return r.formatDefault(opts)
+}
+
+// formatPrint outputs only the specified fields.
+func (r AddResult) formatPrint(fields []string) FormatResult {
+	var stdout strings.Builder
+	for _, field := range fields {
+		switch field {
+		case "path":
+			stdout.WriteString(r.WorktreePath)
+			stdout.WriteString("\n")
+		}
+	}
+	return FormatResult{Stdout: stdout.String()}
+}
+
+// formatDefault outputs the default or verbose format.
+func (r AddResult) formatDefault(opts AddFormatOptions) FormatResult {
 	var stdout, stderr strings.Builder
 
 	var createdCount int

--- a/cmd/gwt/main.go
+++ b/cmd/gwt/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/708u/gwt"
 	"github.com/spf13/cobra"
@@ -102,6 +103,7 @@ var addCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		verbose, _ := cmd.Flags().GetBool("verbose")
 		sync, _ := cmd.Flags().GetBool("sync")
+		printFlag, _ := cmd.Flags().GetString("print")
 
 		addCmd := gwt.NewAddCommand(cfg, gwt.AddOptions{Sync: sync})
 		result, err := addCmd.Run(args[0])
@@ -109,7 +111,17 @@ var addCmd = &cobra.Command{
 			return err
 		}
 
-		formatted := result.Format(gwt.FormatOptions{Verbose: verbose})
+		var printFields []string
+		if printFlag != "" {
+			printFields = strings.Split(printFlag, ",")
+			if err := gwt.ValidatePrintFields(printFields); err != nil {
+				return err
+			}
+		}
+		formatted := result.Format(gwt.AddFormatOptions{
+			Verbose: verbose,
+			Print:   printFields,
+		})
 		if formatted.Stderr != "" {
 			fmt.Fprint(os.Stderr, formatted.Stderr)
 		}
@@ -205,6 +217,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
 
 	addCmd.Flags().BoolP("sync", "s", false, "Sync uncommitted changes to new worktree")
+	addCmd.Flags().String("print", "", "Print specific field (path)")
 	rootCmd.AddCommand(addCmd)
 
 	listCmd.Flags().BoolP("path", "p", false, "Show full paths instead of branch names")

--- a/docs/commands/add.md
+++ b/docs/commands/add.md
@@ -14,9 +14,10 @@ gwt add <name> [flags]
 
 ## Flags
 
-| Flag     | Short | Description                               |
-|----------|-------|-------------------------------------------|
-| `--sync` | `-s`  | Sync uncommitted changes to new worktree  |
+| Flag            | Short | Description                               |
+|-----------------|-------|-------------------------------------------|
+| `--sync`        | `-s`  | Sync uncommitted changes to new worktree  |
+| `--print <field>` |     | Print specific field (path)               |
 
 ## Behavior
 
@@ -38,3 +39,18 @@ With `--sync`, uncommitted changes are copied to the new worktree:
 
 If worktree creation or stash apply fails, changes are restored
 to the source worktree automatically.
+
+### Print Option
+
+With `--print`, only the specified field is output to stdout.
+This is useful for piping to other commands.
+
+```bash
+cd $(gwt add feat/x --print path)
+```
+
+Available fields:
+
+- `path`: Worktree path
+
+When `--print` is specified, `--verbose` is ignored.


### PR DESCRIPTION
## Summary

`gwt add` コマンドに `--print` フラグを追加し、パイプ連携を容易にする。

## Changes

- `AddFormatOptions` 構造体を追加し、`Print` フィールドで出力フィールドを指定可能に
- `ValidatePrintFields()` で不正なフィールド名をバリデーション
- `--print path` でworktreeパスのみを出力

## Usage

```bash
# パスのみ出力
gwt add feat/x --print path

# パイプ連携（VS Codeで開く）
gwt add feat/x --print path | xargs code

# cdで移動
cd $(gwt add feat/x --print path)
```

## Design Decisions

- `--print` 指定時は `--verbose` を無視
- warnings は `--print` 指定時も stderr に出力（将来対応）
- 不正な `--print` 値はエラーを返す
- 将来的に `branch` 等のフィールドを追加可能

## Test Plan

- [x] `TestAddResult_Format` - Format() のユニットテスト
- [x] `TestValidatePrintFields` - バリデーションのユニットテスト
- [x] `PrintPathOutputsOnlyPath` - E2E テスト