### PR TITLE
feat(add): support multiple branch names in single command

### DIFF
--- a/add_integration_test.go
+++ b/add_integration_test.go
@@ -47,10 +47,14 @@ worktree_destination_base_dir = %q
 			Config: result.Config,
 		}
 
-		addResult, err := cmd.Run("feature/test")
+		batchResult, err := cmd.Run([]string{"feature/test"})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
 		}
+		if batchResult.HasErrors() {
+			t.Fatalf("unexpected error: %v", batchResult.Added[0].Err)
+		}
+		addResult := batchResult.Added[0].AddResult
 
 		wtPath := filepath.Join(repoDir, "feature", "test")
 		if _, err := os.Stat(wtPath); os.IsNotExist(err) {
@@ -123,9 +127,12 @@ worktree_destination_base_dir = %q
 			Config: result.Config,
 		}
 
-		_, err = cmd.Run("feature/default-dest")
+		batchResult, err := cmd.Run([]string{"feature/default-dest"})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
+		}
+		if batchResult.HasErrors() {
+			t.Fatalf("unexpected error: %v", batchResult.Added[0].Err)
 		}
 
 		// Worktree should be created in ${repoName}-worktree/${branch}
@@ -170,9 +177,12 @@ worktree_destination_base_dir = %q
 			Config: result.Config,
 		}
 
-		_, err = cmd.Run("existing-branch")
+		batchResult, err := cmd.Run([]string{"existing-branch"})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
+		}
+		if batchResult.HasErrors() {
+			t.Fatalf("unexpected error: %v", batchResult.Added[0].Err)
 		}
 
 		wtPath := filepath.Join(repoDir, "existing-branch")
@@ -211,12 +221,16 @@ worktree_destination_base_dir = %q
 			Config: result.Config,
 		}
 
-		_, err = cmd.Run("test-branch")
-		if err == nil {
-			t.Fatal("expected error, got nil")
+		batchResult, err := cmd.Run([]string{"test-branch"})
+		if err != nil {
+			t.Fatalf("unexpected batch error: %v", err)
 		}
-		if !strings.Contains(err.Error(), "already checked out") {
-			t.Errorf("error %q should contain 'already checked out'", err.Error())
+		if !batchResult.HasErrors() {
+			t.Fatal("expected error, got none")
+		}
+		itemErr := batchResult.Added[0].Err
+		if !strings.Contains(itemErr.Error(), "already checked out") {
+			t.Errorf("error %q should contain 'already checked out'", itemErr.Error())
 		}
 	})
 
@@ -270,9 +284,12 @@ worktree_destination_base_dir = %q
 			Config: result.Config,
 		}
 
-		_, err = cmd.Run("feature/local-merge")
+		batchResult, err := cmd.Run([]string{"feature/local-merge"})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
+		}
+		if batchResult.HasErrors() {
+			t.Fatalf("unexpected error: %v", batchResult.Added[0].Err)
 		}
 
 		wtPath := filepath.Join(repoDir, "feature", "local-merge")
@@ -336,10 +353,14 @@ worktree_destination_base_dir = %q
 			Config: result.Config,
 		}
 
-		addResult, err := cmd.Run("feature/warn-test")
+		batchResult, err := cmd.Run([]string{"feature/warn-test"})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
 		}
+		if batchResult.HasErrors() {
+			t.Fatalf("unexpected error: %v", batchResult.Added[0].Err)
+		}
+		addResult := batchResult.Added[0].AddResult
 
 		// Verify worktree was created successfully
 		wtPath := filepath.Join(repoDir, "feature", "warn-test")
@@ -422,9 +443,12 @@ worktree_destination_base_dir = %q
 			Config: result.Config,
 		}
 
-		_, err = cmd.Run("feature/glob-test")
+		batchResult, err := cmd.Run([]string{"feature/glob-test"})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
+		}
+		if batchResult.HasErrors() {
+			t.Fatalf("unexpected error: %v", batchResult.Added[0].Err)
 		}
 
 		wtPath := filepath.Join(repoDir, "feature", "glob-test")
@@ -500,10 +524,14 @@ worktree_destination_base_dir = %q
 			Sync:   true,
 		}
 
-		addResult, err := cmd.Run("feature/sync-test")
+		batchResult, err := cmd.Run([]string{"feature/sync-test"})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
 		}
+		if batchResult.HasErrors() {
+			t.Fatalf("unexpected error: %v", batchResult.Added[0].Err)
+		}
+		addResult := batchResult.Added[0].AddResult
 
 		// Verify ChangesSynced is true
 		if !addResult.ChangesSynced {
@@ -569,10 +597,14 @@ worktree_destination_base_dir = %q
 			Sync:   true,
 		}
 
-		addResult, err := cmd.Run("feature/no-changes")
+		batchResult, err := cmd.Run([]string{"feature/no-changes"})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
 		}
+		if batchResult.HasErrors() {
+			t.Fatalf("unexpected error: %v", batchResult.Added[0].Err)
+		}
+		addResult := batchResult.Added[0].AddResult
 
 		// Verify ChangesSynced is false (no changes to sync)
 		if addResult.ChangesSynced {
@@ -614,10 +646,14 @@ worktree_destination_base_dir = %q
 			Config: result.Config,
 		}
 
-		addResult, err := cmd.Run("feature/print-test")
+		batchResult, err := cmd.Run([]string{"feature/print-test"})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
 		}
+		if batchResult.HasErrors() {
+			t.Fatalf("unexpected error: %v", batchResult.Added[0].Err)
+		}
+		addResult := batchResult.Added[0].AddResult
 
 		// Verify worktree path matches expected
 		wtPath := filepath.Join(repoDir, "feature", "print-test")
@@ -635,6 +671,146 @@ worktree_destination_base_dir = %q
 		// Verify the path is a valid directory
 		if _, err := os.Stat(wtPath); os.IsNotExist(err) {
 			t.Errorf("worktree directory does not exist: %s", wtPath)
+		}
+	})
+
+	t.Run("AddMultipleWorktrees", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		gwtDir := filepath.Join(mainDir, ".gwt")
+		if err := os.MkdirAll(gwtDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		settingsContent := fmt.Sprintf(`worktree_source_dir = %q
+worktree_destination_base_dir = %q
+symlinks = [".envrc"]
+`, mainDir, repoDir)
+		if err := os.WriteFile(filepath.Join(gwtDir, "settings.toml"), []byte(settingsContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(mainDir, ".envrc"), []byte("# envrc"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LoadConfig(mainDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := &AddCommand{
+			FS:     osFS{},
+			Git:    NewGitRunner(mainDir),
+			Config: result.Config,
+		}
+
+		branches := []string{"feature/a", "feature/b", "feature/c"}
+		batchResult, err := cmd.Run(branches)
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		if batchResult.HasErrors() {
+			t.Fatalf("unexpected errors: %v", batchResult.Added)
+		}
+
+		if len(batchResult.Added) != 3 {
+			t.Errorf("expected 3 added, got %d", len(batchResult.Added))
+		}
+
+		// Verify all worktrees exist
+		for _, branch := range branches {
+			wtPath := filepath.Join(repoDir, branch)
+			if _, err := os.Stat(wtPath); os.IsNotExist(err) {
+				t.Errorf("worktree not created: %s", wtPath)
+			}
+		}
+
+		// Verify git worktree list contains all branches
+		out := testutil.RunGit(t, mainDir, "worktree", "list")
+		for _, branch := range branches {
+			if !strings.Contains(out, branch) {
+				t.Errorf("worktree list does not contain %s: %s", branch, out)
+			}
+		}
+	})
+
+	t.Run("SyncWithMultipleWorktrees", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		gwtDir := filepath.Join(mainDir, ".gwt")
+		if err := os.MkdirAll(gwtDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		settingsContent := fmt.Sprintf(`worktree_source_dir = %q
+worktree_destination_base_dir = %q
+`, mainDir, repoDir)
+		if err := os.WriteFile(filepath.Join(gwtDir, "settings.toml"), []byte(settingsContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Commit settings first
+		testutil.RunGit(t, mainDir, "add", ".gwt")
+		testutil.RunGit(t, mainDir, "commit", "-m", "add gwt settings")
+
+		// Create uncommitted changes
+		modifiedFile := filepath.Join(mainDir, "sync-content.txt")
+		if err := os.WriteFile(modifiedFile, []byte("sync content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LoadConfig(mainDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := &AddCommand{
+			FS:     osFS{},
+			Git:    NewGitRunner(mainDir),
+			Config: result.Config,
+			Sync:   true,
+		}
+
+		branches := []string{"feature/sync-a", "feature/sync-b"}
+		batchResult, err := cmd.Run(branches)
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		if batchResult.HasErrors() {
+			t.Fatalf("unexpected errors: %v", batchResult.Added)
+		}
+
+		if !batchResult.ChangesSynced {
+			t.Error("expected ChangesSynced to be true")
+		}
+
+		// Verify changes exist in both worktrees
+		for _, branch := range branches {
+			wtPath := filepath.Join(repoDir, branch)
+			syncedFile := filepath.Join(wtPath, "sync-content.txt")
+			content, err := os.ReadFile(syncedFile)
+			if err != nil {
+				t.Errorf("failed to read synced file in %s: %v", branch, err)
+				continue
+			}
+			if string(content) != "sync content" {
+				t.Errorf("synced file content in %s = %q, want %q", branch, string(content), "sync content")
+			}
+		}
+
+		// Verify source still has the file (stash was popped)
+		sourceContent, err := os.ReadFile(modifiedFile)
+		if err != nil {
+			t.Fatalf("failed to read source file: %v", err)
+		}
+		if string(sourceContent) != "sync content" {
+			t.Errorf("source file content = %q, want %q", string(sourceContent), "sync content")
 		}
 	})
 }

--- a/add_test.go
+++ b/add_test.go
@@ -79,7 +79,7 @@ func TestAddCommand_Run(t *testing.T) {
 		{
 			name:   "empty_name",
 			branch: "",
-			config: &Config{WorktreeSourceDir: "/repo/main"},
+			config: &Config{WorktreeSourceDir: "/repo/main", WorktreeDestBaseDir: "/repo/main-worktree"},
 			setupFS: func(t *testing.T) *testutil.MockFS {
 				t.Helper()
 				return &testutil.MockFS{}
@@ -257,20 +257,35 @@ func TestAddCommand_Run(t *testing.T) {
 				Sync:   tt.sync,
 			}
 
-			result, err := cmd.Run(tt.branch)
+			batchResult, err := cmd.Run([]string{tt.branch})
 
 			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
+				// Check batch-level error or individual item error
+				if err != nil {
+					if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+						t.Errorf("error %q should contain %q", err.Error(), tt.errContains)
+					}
+					return
 				}
-				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
-					t.Errorf("error %q should contain %q", err.Error(), tt.errContains)
+				// Check individual item error
+				if len(batchResult.Added) == 0 {
+					t.Fatal("expected error, got empty result")
+				}
+				if batchResult.Added[0].Err == nil {
+					t.Fatal("expected error in result, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(batchResult.Added[0].Err.Error(), tt.errContains) {
+					t.Errorf("error %q should contain %q", batchResult.Added[0].Err.Error(), tt.errContains)
 				}
 				return
 			}
 
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if batchResult.HasErrors() {
+				t.Fatalf("unexpected errors in batch result: %v", batchResult.Added[0].Err)
 			}
 
 			if tt.wantBFlag && !slices.Contains(captured, "-b") {
@@ -285,6 +300,7 @@ func TestAddCommand_Run(t *testing.T) {
 				t.Errorf("expected path %q in args, got: %v", tt.checkPath, captured)
 			}
 
+			result := batchResult.Added[0].AddResult
 			if result.ChangesSynced != tt.wantSynced {
 				t.Errorf("ChangesSynced = %v, want %v", result.ChangesSynced, tt.wantSynced)
 			}
@@ -511,6 +527,318 @@ func TestAddCommand_createSymlinks(t *testing.T) {
 			}
 			if created != tt.wantCreated {
 				t.Errorf("got %d created, want %d", created, tt.wantCreated)
+			}
+		})
+	}
+}
+
+func TestAddBatchResult_HasErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		result AddBatchResult
+		want   bool
+	}{
+		{
+			name:   "empty",
+			result: AddBatchResult{},
+			want:   false,
+		},
+		{
+			name: "success_only",
+			result: AddBatchResult{
+				Added: []AddedWorktree{{AddResult: AddResult{Branch: "a"}}},
+			},
+			want: false,
+		},
+		{
+			name: "error_only",
+			result: AddBatchResult{
+				Added: []AddedWorktree{{AddResult: AddResult{Branch: "b"}, Err: errors.New("fail")}},
+			},
+			want: true,
+		},
+		{
+			name: "mixed",
+			result: AddBatchResult{
+				Added: []AddedWorktree{
+					{AddResult: AddResult{Branch: "a"}},
+					{AddResult: AddResult{Branch: "b"}, Err: errors.New("fail")},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.result.HasErrors(); got != tt.want {
+				t.Errorf("HasErrors() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddBatchResult_ErrorCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		result AddBatchResult
+		want   int
+	}{
+		{
+			name:   "empty",
+			result: AddBatchResult{},
+			want:   0,
+		},
+		{
+			name: "no_errors",
+			result: AddBatchResult{
+				Added: []AddedWorktree{
+					{AddResult: AddResult{Branch: "a"}},
+					{AddResult: AddResult{Branch: "b"}},
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "one_error",
+			result: AddBatchResult{
+				Added: []AddedWorktree{
+					{AddResult: AddResult{Branch: "a"}},
+					{AddResult: AddResult{Branch: "b"}, Err: errors.New("fail")},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "all_errors",
+			result: AddBatchResult{
+				Added: []AddedWorktree{
+					{AddResult: AddResult{Branch: "a"}, Err: errors.New("fail1")},
+					{AddResult: AddResult{Branch: "b"}, Err: errors.New("fail2")},
+				},
+			},
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.result.ErrorCount(); got != tt.want {
+				t.Errorf("ErrorCount() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddBatchResult_Format(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		result     AddBatchResult
+		opts       AddFormatOptions
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			name: "single_success",
+			result: AddBatchResult{
+				Added: []AddedWorktree{
+					{AddResult: AddResult{Branch: "feature/a", WorktreePath: "/wt/feature/a", Symlinks: []SymlinkResult{{Src: "/src", Dst: "/dst"}}}},
+				},
+			},
+			opts:       AddFormatOptions{},
+			wantStdout: "gwt add: feature/a (1 symlinks)\n",
+			wantStderr: "",
+		},
+		{
+			name: "multiple_success",
+			result: AddBatchResult{
+				Added: []AddedWorktree{
+					{AddResult: AddResult{Branch: "feature/a", WorktreePath: "/wt/feature/a"}},
+					{AddResult: AddResult{Branch: "feature/b", WorktreePath: "/wt/feature/b"}},
+				},
+			},
+			opts:       AddFormatOptions{},
+			wantStdout: "gwt add: feature/a (0 symlinks)\ngwt add: feature/b (0 symlinks)\n",
+			wantStderr: "",
+		},
+		{
+			name: "print_path_multiple",
+			result: AddBatchResult{
+				Added: []AddedWorktree{
+					{AddResult: AddResult{Branch: "feature/a", WorktreePath: "/wt/feature/a"}},
+					{AddResult: AddResult{Branch: "feature/b", WorktreePath: "/wt/feature/b"}},
+				},
+			},
+			opts:       AddFormatOptions{Print: []string{"path"}},
+			wantStdout: "/wt/feature/a\n/wt/feature/b\n",
+			wantStderr: "",
+		},
+		{
+			name: "mixed_success_and_error",
+			result: AddBatchResult{
+				Added: []AddedWorktree{
+					{AddResult: AddResult{Branch: "feature/a", WorktreePath: "/wt/feature/a"}},
+					{AddResult: AddResult{Branch: "feature/b"}, Err: errors.New("directory already exists")},
+				},
+			},
+			opts:       AddFormatOptions{},
+			wantStdout: "gwt add: feature/a (0 symlinks)\n",
+			wantStderr: "error: feature/b: directory already exists\n",
+		},
+		{
+			name: "print_path_with_error",
+			result: AddBatchResult{
+				Added: []AddedWorktree{
+					{AddResult: AddResult{Branch: "feature/a", WorktreePath: "/wt/feature/a"}},
+					{AddResult: AddResult{Branch: "feature/b"}, Err: errors.New("fail")},
+				},
+			},
+			opts:       AddFormatOptions{Print: []string{"path"}},
+			wantStdout: "/wt/feature/a\n",
+			wantStderr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.result.Format(tt.opts)
+
+			if got.Stdout != tt.wantStdout {
+				t.Errorf("Stdout = %q, want %q", got.Stdout, tt.wantStdout)
+			}
+			if got.Stderr != tt.wantStderr {
+				t.Errorf("Stderr = %q, want %q", got.Stderr, tt.wantStderr)
+			}
+		})
+	}
+}
+
+func TestAddCommand_Run_Multiple(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		branches     []string
+		config       *Config
+		sync         bool
+		setupFS      func(t *testing.T) *testutil.MockFS
+		setupGit     func(t *testing.T) *testutil.MockGitExecutor
+		wantErr      bool
+		wantErrCount int
+		wantSynced   bool
+	}{
+		{
+			name:     "multiple_success",
+			branches: []string{"feature/a", "feature/b"},
+			config:   &Config{WorktreeSourceDir: "/repo/main", WorktreeDestBaseDir: "/repo/worktrees"},
+			setupFS: func(t *testing.T) *testutil.MockFS {
+				t.Helper()
+				return &testutil.MockFS{}
+			},
+			setupGit: func(t *testing.T) *testutil.MockGitExecutor {
+				t.Helper()
+				return &testutil.MockGitExecutor{}
+			},
+			wantErr:      false,
+			wantErrCount: 0,
+		},
+		{
+			name:     "partial_failure",
+			branches: []string{"feature/ok", "existing"},
+			config:   &Config{WorktreeSourceDir: "/repo/main", WorktreeDestBaseDir: "/repo/worktrees"},
+			setupFS: func(t *testing.T) *testutil.MockFS {
+				t.Helper()
+				return &testutil.MockFS{
+					ExistingPaths: []string{"/repo/worktrees/existing"},
+				}
+			},
+			setupGit: func(t *testing.T) *testutil.MockGitExecutor {
+				t.Helper()
+				return &testutil.MockGitExecutor{}
+			},
+			wantErr:      false,
+			wantErrCount: 1,
+		},
+		{
+			name:     "sync_with_multiple",
+			branches: []string{"feature/a", "feature/b"},
+			config:   &Config{WorktreeSourceDir: "/repo/main", WorktreeDestBaseDir: "/repo/worktrees"},
+			sync:     true,
+			setupFS: func(t *testing.T) *testutil.MockFS {
+				t.Helper()
+				return &testutil.MockFS{}
+			},
+			setupGit: func(t *testing.T) *testutil.MockGitExecutor {
+				t.Helper()
+				return &testutil.MockGitExecutor{HasChanges: true}
+			},
+			wantErr:    false,
+			wantSynced: true,
+		},
+		{
+			name:     "empty_branches",
+			branches: []string{},
+			config:   &Config{WorktreeSourceDir: "/repo/main", WorktreeDestBaseDir: "/repo/worktrees"},
+			setupFS: func(t *testing.T) *testutil.MockFS {
+				t.Helper()
+				return &testutil.MockFS{}
+			},
+			setupGit: func(t *testing.T) *testutil.MockGitExecutor {
+				t.Helper()
+				return &testutil.MockGitExecutor{}
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockFS := tt.setupFS(t)
+			mockGit := tt.setupGit(t)
+
+			cmd := &AddCommand{
+				FS:     mockFS,
+				Git:    &GitRunner{Executor: mockGit},
+				Config: tt.config,
+				Sync:   tt.sync,
+			}
+
+			result, err := cmd.Run(tt.branches)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result.ErrorCount() != tt.wantErrCount {
+				t.Errorf("ErrorCount() = %d, want %d", result.ErrorCount(), tt.wantErrCount)
+			}
+
+			if result.ChangesSynced != tt.wantSynced {
+				t.Errorf("ChangesSynced = %v, want %v", result.ChangesSynced, tt.wantSynced)
+			}
+
+			// Verify correct number of results
+			if len(result.Added) != len(tt.branches) {
+				t.Errorf("len(Added) = %d, want %d", len(result.Added), len(tt.branches))
 			}
 		})
 	}

--- a/docs/commands/add.md
+++ b/docs/commands/add.md
@@ -1,44 +1,47 @@
 # add subcommand
 
-Create a new worktree with optional symlinks.
+Create worktrees with optional symlinks.
 
 ## Usage
 
 ```txt
-gwt add <name> [flags]
+gwt add <name>... [flags]
 ```
 
 ## Arguments
 
-- `<name>`: Branch name (required)
+- `<name>...`: One or more branch names (required)
 
 ## Flags
 
-| Flag            | Short | Description                               |
-|-----------------|-------|-------------------------------------------|
-| `--sync`        | `-s`  | Sync uncommitted changes to new worktree  |
-| `--print <field>` |     | Print specific field (path)               |
+| Flag              | Short | Description                                |
+|-------------------|-------|--------------------------------------------|
+| `--sync`          | `-s`  | Sync uncommitted changes to new worktrees  |
+| `--print <field>` |       | Print specific field (path)                |
 
 ## Behavior
 
-- Creates worktree at `WorktreeDestBaseDir/<name>`
-- If the branch already exists, uses that branch
-- If the branch doesn't exist, creates a new branch with `-b` flag
-- Creates symlinks from `WorktreeSourceDir` to worktree
+- Creates worktrees at `WorktreeDestBaseDir/<name>` for each branch
+- If a branch already exists, uses that branch
+- If a branch doesn't exist, creates a new branch with `-b` flag
+- Creates symlinks from `WorktreeSourceDir` to worktrees
   based on `Config.Symlinks` patterns
 - Warns when symlink patterns don't match any files
+- Errors on individual branches do not stop processing of remaining branches
+- Exit code 0 if all succeed, 1 if any fail
 
 ### Sync Option
 
-With `--sync`, uncommitted changes are copied to the new worktree:
+With `--sync`, uncommitted changes are copied to all new worktrees:
 
-1. Stashes current changes
-2. Creates the new worktree
-3. Applies stash to new worktree
-4. Restores changes in the source worktree
+1. Stashes current changes (once)
+2. For each branch:
+   - Creates the new worktree
+   - Applies stash to new worktree
+3. Restores changes in the source worktree (pops stash)
 
-If worktree creation or stash apply fails, changes are restored
-to the source worktree automatically.
+If a worktree creation or stash apply fails, that branch is skipped
+but processing continues for remaining branches.
 
 ### Print Option
 
@@ -54,3 +57,19 @@ Available fields:
 - `path`: Worktree path
 
 When `--print` is specified, `--verbose` is ignored.
+
+## Examples
+
+```bash
+# Create single worktree
+gwt add feature/new-feature
+
+# Create multiple worktrees
+gwt add feature/a feature/b feature/c
+
+# Sync changes to multiple worktrees
+gwt add --sync feature/a feature/b
+
+# Print paths for scripting
+gwt add --print path feature/a feature/b
+```


### PR DESCRIPTION
## Summary

- `gwt add` コマンドで複数のブランチ名を指定可能に
- `--sync` オプション使用時は一度だけstashして全worktreeに適用
- 個別のブランチでエラーが発生しても残りの処理は継続

## Changes

- `AddBatchResult` 型を追加し、複数操作の結果を集約
- `Run()` メソッドを `[]string` 受け取りに変更
- CLIを `cobra.MinimumNArgs(1)` に変更し複数引数対応
- 補完で既に指定済みのブランチを除外

## Test plan

- [x] 単体テスト追加 (`TestAddCommand_Run_Multiple`, `TestAddBatchResult_*`)
- [x] 統合テスト追加 (`AddMultipleWorktrees`, `SyncWithMultipleWorktrees`)
- [x] 既存テストをバッチAPIに対応

```bash
go test ./...
go test -tags=integration ./...
```