### PR TITLE
refactor(list): change default output to git worktree list compatible format

### DIFF
--- a/.claude/rules/commands/list.md
+++ b/.claude/rules/commands/list.md
@@ -1,39 +1,33 @@
 # list subcommand
 
-List all worktrees.
+List all worktrees in `git worktree list` compatible format.
 
 ## Usage
 
 ```txt
-gwt list [flags]
+gwt list
 ```
-
-## Flags
-
-| Flag     | Short | Description                              |
-|----------|-------|------------------------------------------|
-| `--path` | `-p`  | Show full paths instead of branch names  |
 
 ## Behavior
 
 - Lists all worktrees including the main worktree
-- Default output shows branch names only
-- With `--path`: shows full filesystem paths
+- Output format is compatible with `git worktree list`
+- Shows path, short commit hash, and branch name for each worktree
+- Displays additional status: locked, prunable, detached HEAD
 
 ## Examples
 
 ```txt
-# List branch names
 gwt list
-main
-feat/add-list-command
-feat/add-move-command
+/Users/user/repo                                   d9ef543 [main]
+/Users/user/repo-worktree/feat/add-list-command    abc1234 [feat/add-list-command]
+/Users/user/repo-worktree/feat/add-move-command    def5678 [feat/add-move-command]
 
-# List full paths (for cd integration)
-gwt list --path
-/Users/user/repo
-/Users/user/repo-worktree/feat/add-list-command
-/Users/user/repo-worktree/feat/add-move-command
+# Detached HEAD example
+/Users/user/repo-worktree/detached                 1234abc (detached HEAD)
+
+# Locked worktree example
+/Users/user/repo-worktree/locked                   5678def [locked-branch] locked
 ```
 
 ## Shell Integration
@@ -43,7 +37,7 @@ Combine with fzf for quick worktree navigation:
 ```bash
 gcd() {
   local selected
-  selected=$(gwt list --path | fzf +m) &&
+  selected=$(gwt list | awk '{print $1}' | fzf +m) &&
   cd "$selected"
 }
 ```

--- a/cmd/gwt/main.go
+++ b/cmd/gwt/main.go
@@ -127,14 +127,12 @@ var listCmd = &cobra.Command{
 	Short: "List all worktrees",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		showPath, _ := cmd.Flags().GetBool("path")
-
 		result, err := gwt.NewListCommand(cwd).Run()
 		if err != nil {
 			return err
 		}
 
-		formatted := result.Format(gwt.ListFormatOptions{ShowPath: showPath})
+		formatted := result.Format()
 		fmt.Fprint(os.Stdout, formatted.Stdout)
 		return nil
 	},
@@ -212,7 +210,6 @@ func init() {
 	addCmd.Flags().BoolP("quiet", "q", false, "Output only the worktree path")
 	rootCmd.AddCommand(addCmd)
 
-	listCmd.Flags().BoolP("path", "p", false, "Show full paths instead of branch names")
 	rootCmd.AddCommand(listCmd)
 
 	removeCmd.Flags().BoolP("force", "f", false, "Force removal even with uncommitted changes or unmerged branch")

--- a/internal/testutil/mock_git.go
+++ b/internal/testutil/mock_git.go
@@ -8,9 +8,15 @@ import (
 
 // MockWorktree represents a worktree entry for testing.
 type MockWorktree struct {
-	Path   string
-	Branch string
-	HEAD   string
+	Path           string
+	Branch         string
+	HEAD           string
+	Detached       bool
+	Locked         bool
+	LockReason     string
+	Prunable       bool
+	PrunableReason string
+	Bare           bool
 }
 
 // MockGitExecutor is a mock implementation of gwt.GitExecutor for testing.
@@ -118,11 +124,31 @@ func (m *MockGitExecutor) handleWorktreeList() ([]byte, error) {
 	for _, wt := range m.Worktrees {
 		head := wt.HEAD
 		if head == "" {
-			head = "abc123"
+			head = "abc1234567890"
 		}
 		lines = append(lines, "worktree "+wt.Path)
 		lines = append(lines, "HEAD "+head)
-		lines = append(lines, "branch refs/heads/"+wt.Branch)
+		if wt.Bare {
+			lines = append(lines, "bare")
+		} else if wt.Detached {
+			lines = append(lines, "detached")
+		} else {
+			lines = append(lines, "branch refs/heads/"+wt.Branch)
+		}
+		if wt.Locked {
+			if wt.LockReason != "" {
+				lines = append(lines, "locked "+wt.LockReason)
+			} else {
+				lines = append(lines, "locked")
+			}
+		}
+		if wt.Prunable {
+			if wt.PrunableReason != "" {
+				lines = append(lines, "prunable "+wt.PrunableReason)
+			} else {
+				lines = append(lines, "prunable")
+			}
+		}
 		lines = append(lines, "")
 	}
 	return []byte(strings.Join(lines, "\n")), nil

--- a/list.go
+++ b/list.go
@@ -21,25 +21,44 @@ type ListResult struct {
 	Worktrees []WorktreeInfo
 }
 
-// ListFormatOptions configures list output formatting.
-type ListFormatOptions struct {
-	ShowPath bool
-}
-
-// Format formats the ListResult for display.
-func (r ListResult) Format(opts ListFormatOptions) FormatResult {
+// Format formats the ListResult for display in git worktree list compatible format.
+func (r ListResult) Format() FormatResult {
 	var stdout strings.Builder
 
 	for _, wt := range r.Worktrees {
-		if opts.ShowPath {
-			stdout.WriteString(wt.Path)
-		} else {
-			stdout.WriteString(wt.Branch)
-		}
+		stdout.WriteString(wt.formatLine())
 		stdout.WriteString("\n")
 	}
 
 	return FormatResult{Stdout: stdout.String()}
+}
+
+// formatLine returns git worktree list compatible format for a single worktree.
+func (w WorktreeInfo) formatLine() string {
+	var sb strings.Builder
+	sb.WriteString(w.Path)
+	sb.WriteString("  ")
+	sb.WriteString(w.ShortHEAD())
+	sb.WriteString(" ")
+
+	if w.Bare {
+		sb.WriteString("(bare)")
+	} else if w.Detached {
+		sb.WriteString("(detached HEAD)")
+	} else {
+		sb.WriteString("[")
+		sb.WriteString(w.Branch)
+		sb.WriteString("]")
+	}
+
+	if w.Locked {
+		sb.WriteString(" locked")
+	}
+	if w.Prunable {
+		sb.WriteString(" prunable")
+	}
+
+	return sb.String()
 }
 
 // Run lists all worktrees.


### PR DESCRIPTION
## Summary

`gwt list` コマンドのデフォルト出力を `git worktree list` 互換形式に変更。

## Changes

- WorktreeInfo 構造体に HEAD, Detached, Locked, Prunable, Bare フィールドを追加
- `git worktree list --porcelain` の全フィールドをパース
- デフォルトでパス、短いコミットハッシュ、ブランチ名を表示
- locked/prunable/detached 状態のアノテーションを表示
- `--path` フラグを削除（パスはデフォルトで表示されるため不要）

## Example Output

```txt
gwt list
/Users/user/repo                   d9ef543 [main]
/Users/user/repo-worktree/feat/a   abc1234 [feat/a]
/Users/user/repo-worktree/detached 1234abc (detached HEAD)
/Users/user/repo-worktree/locked   5678def [branch] locked
```

## Test Plan

- [x] Unit tests updated
- [x] Integration tests updated
- [x] Manual testing completed