### PR TITLE
docs(rules): add documentation update step to development workflow

### DIFF
--- a/.claude/rules/development-workflow.md
+++ b/.claude/rules/development-workflow.md
@@ -45,7 +45,15 @@ Review and update tests to ensure coverage:
   - Modify existing tests
   - Remove obsolete tests
 
-### 4. Verify All Tests Pass
+### 4. Update Documentation
+
+If the changes affect subcommand behavior, update the documentation:
+
+- Update the corresponding file in @docs/commands/
+- Document new flags, arguments, or behavior changes
+- Update examples if needed
+
+### 5. Verify All Tests Pass
 
 Run the full test suite before completing:
 


### PR DESCRIPTION
## Summary

- Add step 4 "Update Documentation" to the development workflow
- Requires updating `docs/commands/` when subcommand behavior changes
- Renumber existing step 4 to step 5

## Test plan

- [ ] Verify the workflow document is correctly formatted
- [ ] Confirm the new step integrates logically with existing workflow