### PR TITLE
fix: suppress Cobra default error output and use custom format

### DIFF
--- a/cmd/gwt/main.go
+++ b/cmd/gwt/main.go
@@ -54,8 +54,10 @@ func resolveCompletionDirectory(cmd *cobra.Command) (string, error) {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "gwt",
-	Short: "Manage git worktrees and branches together",
+	Use:           "gwt",
+	Short:         "Manage git worktrees and branches together",
+	SilenceErrors: true,
+	SilenceUsage:  true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		cwd, err = os.Getwd()
@@ -260,6 +262,7 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, "gwt:", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

- Cobra由来のエラー出力（`Error:` プレフィックスとUsage表示）を抑制
- 独自フォーマット `gwt: <message>` でエラーを出力するように変更

## Changes

- `rootCmd` に `SilenceErrors: true` と `SilenceUsage: true` を設定
- `main()` でエラーを `gwt: <message>` 形式で出力

## Before

```txt
Error: accepts 1 arg(s), received 0
Usage:
  gwt add <name> [flags]
...
```

## After

```txt
gwt: accepts 1 arg(s), received 0
```