### PR TITLE
refactor: add factory pattern to RemoveCommand for CLI testability

### DIFF
--- a/cmd/gwt/main.go
+++ b/cmd/gwt/main.go
@@ -24,8 +24,21 @@ func defaultNewCleanCommander(cfg *gwt.Config) CleanCommander {
 	return gwt.NewDefaultCleanCommand(cfg)
 }
 
+// RemoveCommander defines the interface for remove operations.
+type RemoveCommander interface {
+	Run(branch string, cwd string, opts gwt.RemoveOptions) (gwt.RemovedWorktree, error)
+}
+
+// NewRemoveCommander is the factory function type for creating RemoveCommander instances.
+type NewRemoveCommander func(cfg *gwt.Config) RemoveCommander
+
+func defaultNewRemoveCommander(cfg *gwt.Config) RemoveCommander {
+	return gwt.NewDefaultRemoveCommand(cfg)
+}
+
 type options struct {
-	newCleanCommander NewCleanCommander
+	newCleanCommander  NewCleanCommander
+	newRemoveCommander NewRemoveCommander
 }
 
 // Option configures newRootCmd.
@@ -35,6 +48,13 @@ type Option func(*options)
 func WithNewCleanCommander(ncc NewCleanCommander) Option {
 	return func(o *options) {
 		o.newCleanCommander = ncc
+	}
+}
+
+// WithNewRemoveCommander sets the factory function for creating RemoveCommander instances.
+func WithNewRemoveCommander(nrc NewRemoveCommander) Option {
+	return func(o *options) {
+		o.newRemoveCommander = nrc
 	}
 }
 
@@ -68,7 +88,8 @@ func resolveDirectory(dirFlag, baseCwd string) (string, error) {
 
 func newRootCmd(opts ...Option) *cobra.Command {
 	o := &options{
-		newCleanCommander: defaultNewCleanCommander,
+		newCleanCommander:  defaultNewCleanCommander,
+		newRemoveCommander: defaultNewRemoveCommander,
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -371,7 +392,7 @@ stop processing of remaining branches.`,
 			force, _ := cmd.Flags().GetBool("force")
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
 
-			removeCmd := gwt.NewRemoveCommand(cfg)
+			removeCmd := o.newRemoveCommander(cfg)
 			var result gwt.RemoveResult
 
 			for _, branch := range args {

--- a/cmd/gwt/main_test.go
+++ b/cmd/gwt/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -204,5 +205,206 @@ func TestCleanCmd(t *testing.T) {
 				t.Errorf("stdout = %q, want %q", stdout.String(), tt.wantStdout)
 			}
 		})
+	}
+}
+
+// mockRemoveCommander implements RemoveCommander for testing.
+type mockRemoveCommander struct {
+	calls   []removeCall
+	results []removeResult
+	idx     int
+}
+
+type removeCall struct {
+	branch string
+	cwd    string
+	opts   gwt.RemoveOptions
+}
+
+type removeResult struct {
+	wt  gwt.RemovedWorktree
+	err error
+}
+
+func (m *mockRemoveCommander) Run(branch, cwd string, opts gwt.RemoveOptions) (gwt.RemovedWorktree, error) {
+	m.calls = append(m.calls, removeCall{branch, cwd, opts})
+	if m.idx < len(m.results) {
+		r := m.results[m.idx]
+		m.idx++
+		return r.wt, r.err
+	}
+	return gwt.RemovedWorktree{Branch: branch, WorktreePath: "/test/" + branch}, nil
+}
+
+func TestRemoveCmd(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		args      []string
+		wantForce bool
+		wantDry   bool
+	}{
+		{
+			name:      "no_flags",
+			args:      []string{"remove", "feat/a"},
+			wantForce: false,
+			wantDry:   false,
+		},
+		{
+			name:      "force_flag",
+			args:      []string{"remove", "--force", "feat/a"},
+			wantForce: true,
+			wantDry:   false,
+		},
+		{
+			name:      "force_short_flag",
+			args:      []string{"remove", "-f", "feat/a"},
+			wantForce: true,
+			wantDry:   false,
+		},
+		{
+			name:      "dry_run_flag",
+			args:      []string{"remove", "--dry-run", "feat/a"},
+			wantForce: false,
+			wantDry:   true,
+		},
+		{
+			name:      "both_flags",
+			args:      []string{"remove", "--force", "--dry-run", "feat/a"},
+			wantForce: true,
+			wantDry:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &mockRemoveCommander{}
+
+			cmd := newRootCmd(WithNewRemoveCommander(func(cfg *gwt.Config) RemoveCommander {
+				return mock
+			}))
+
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+
+			cmd.SetOut(stdout)
+			cmd.SetErr(stderr)
+			cmd.SetArgs(tt.args)
+
+			_ = cmd.Execute()
+
+			if len(mock.calls) != 1 {
+				t.Fatalf("expected 1 call, got %d", len(mock.calls))
+			}
+
+			call := mock.calls[0]
+			if call.opts.Force != tt.wantForce {
+				t.Errorf("Force = %v, want %v", call.opts.Force, tt.wantForce)
+			}
+			if call.opts.DryRun != tt.wantDry {
+				t.Errorf("DryRun = %v, want %v", call.opts.DryRun, tt.wantDry)
+			}
+		})
+	}
+}
+
+func TestRemoveCmd_OutputFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		args       []string
+		results    []removeResult
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			name: "success_output",
+			args: []string{"remove", "feat/a"},
+			results: []removeResult{
+				{wt: gwt.RemovedWorktree{Branch: "feat/a", WorktreePath: "/test/feat/a"}},
+			},
+			wantStdout: "gwt remove: feat/a\n",
+			wantStderr: "",
+		},
+		{
+			name: "error_output",
+			args: []string{"remove", "feat/a"},
+			results: []removeResult{
+				{wt: gwt.RemovedWorktree{}, err: errors.New("not found")},
+			},
+			wantStdout: "",
+			wantStderr: "error: feat/a: not found\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &mockRemoveCommander{results: tt.results}
+
+			cmd := newRootCmd(WithNewRemoveCommander(func(cfg *gwt.Config) RemoveCommander {
+				return mock
+			}))
+
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+
+			cmd.SetOut(stdout)
+			cmd.SetErr(stderr)
+			cmd.SetArgs(tt.args)
+
+			_ = cmd.Execute()
+
+			if stdout.String() != tt.wantStdout {
+				t.Errorf("stdout = %q, want %q", stdout.String(), tt.wantStdout)
+			}
+			if stderr.String() != tt.wantStderr {
+				t.Errorf("stderr = %q, want %q", stderr.String(), tt.wantStderr)
+			}
+		})
+	}
+}
+
+func TestRemoveCmd_MultipleBranches(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockRemoveCommander{}
+
+	cmd := newRootCmd(WithNewRemoveCommander(func(cfg *gwt.Config) RemoveCommander {
+		return mock
+	}))
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"remove", "feat/a", "feat/b", "feat/c"})
+
+	_ = cmd.Execute()
+
+	if len(mock.calls) != 3 {
+		t.Fatalf("expected 3 calls, got %d", len(mock.calls))
+	}
+
+	branches := []string{mock.calls[0].branch, mock.calls[1].branch, mock.calls[2].branch}
+	expected := []string{"feat/a", "feat/b", "feat/c"}
+	for i, got := range branches {
+		if got != expected[i] {
+			t.Errorf("call[%d].branch = %q, want %q", i, got, expected[i])
+		}
+	}
+
+	// Check output contains all branches
+	out := stdout.String()
+	for _, b := range expected {
+		if !strings.Contains(out, b) {
+			t.Errorf("output should contain %q", b)
+		}
 	}
 }

--- a/remove.go
+++ b/remove.go
@@ -19,13 +19,18 @@ type RemoveOptions struct {
 	DryRun bool
 }
 
-// NewRemoveCommand creates a new RemoveCommand with the given config.
-func NewRemoveCommand(cfg *Config) *RemoveCommand {
+// NewRemoveCommand creates a RemoveCommand with explicit dependencies.
+func NewRemoveCommand(fs FileSystem, git *GitRunner, cfg *Config) *RemoveCommand {
 	return &RemoveCommand{
-		FS:     osFS{},
-		Git:    NewGitRunner(cfg.WorktreeSourceDir),
+		FS:     fs,
+		Git:    git,
 		Config: cfg,
 	}
+}
+
+// NewDefaultRemoveCommand creates a RemoveCommand with production defaults.
+func NewDefaultRemoveCommand(cfg *Config) *RemoveCommand {
+	return NewRemoveCommand(osFS{}, NewGitRunner(cfg.WorktreeSourceDir), cfg)
 }
 
 // RemovedWorktree holds the result of a single worktree removal.


### PR DESCRIPTION
## Why

RemoveCommandにファクトリパターンを適用し、CLIレイヤーのユニットテストを可能にする。
CleanCommandと同様の設計を踏襲する。

## What

- `NewRemoveCommand`を依存注入可能な形式に変更
- `NewDefaultRemoveCommand`を追加（生産デフォルト）
- `RemoveCommander`インターフェースを定義
- `WithNewRemoveCommander`オプションを追加
- mockRemoveCommanderを使ったCLIテストを追加

## Related

- #36 (CleanCommandのファクトリパターン適用)

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Other

## How to Test

```bash
go test ./...
```