### PR TITLE
refactor: remove pure logic tests from integration test file

### DIFF
--- a/cmd/gwt/main_integration_test.go
+++ b/cmd/gwt/main_integration_test.go
@@ -264,26 +264,6 @@ func TestAddCommand_DefaultSource_Integration(t *testing.T) {
 		}
 	})
 
-	t.Run("CliSourceOverridesDefaultSource", func(t *testing.T) {
-		t.Parallel()
-
-		// This test verifies the priority: CLI --source > config default_source
-		// Test by checking the condition logic
-
-		cliSource := "dev"
-		configDefaultSource := "main"
-
-		// CLI source should take precedence
-		effectiveSource := cliSource
-		if effectiveSource == "" && configDefaultSource != "" {
-			effectiveSource = configDefaultSource
-		}
-
-		if effectiveSource != "dev" {
-			t.Errorf("effective source = %q, want %q", effectiveSource, "dev")
-		}
-	})
-
 	t.Run("DefaultSourceAppliedWithDirFlag", func(t *testing.T) {
 		t.Parallel()
 
@@ -316,24 +296,6 @@ func TestAddCommand_DefaultSource_Integration(t *testing.T) {
 		// Since cliSource is empty but default_source is set, effectiveSource should be "main"
 		if effectiveSource != "main" {
 			t.Errorf("effective source = %q, want %q (default_source should be applied with -C)", effectiveSource, "main")
-		}
-	})
-
-	t.Run("SourceFlagOverridesDefaultSourceWithDirFlag", func(t *testing.T) {
-		t.Parallel()
-
-		// This test verifies: -C + --source specified, --source overrides default_source
-		cliSource := "dev"
-		configDefaultSource := "main"
-
-		// CLI source should take precedence even with -C
-		effectiveSource := cliSource
-		if effectiveSource == "" && configDefaultSource != "" {
-			effectiveSource = configDefaultSource
-		}
-
-		if effectiveSource != "dev" {
-			t.Errorf("effective source = %q, want %q (--source should override default_source with -C)", effectiveSource, "dev")
 		}
 	})
 


### PR DESCRIPTION
## Why

統合テストファイル（`main_integration_test.go`）に実I/Oを使わない純粋ロジックテストが
含まれており、統合テストの責務が曖昧になっていた。

## What

以下の2つのテストケースを削除:

- `CliSourceOverridesDefaultSource`: CLI `--source` が `default_source` より優先される
  ことを検証するが、変数の条件分岐のみで実I/Oなし
- `SourceFlagOverridesDefaultSourceWithDirFlag`: `-C` と `--source` の組み合わせで
  `--source` が優先されることを検証するが、同様に実I/Oなし

これらは統合テストとしての価値がなく、削除により統合テストの責務が明確になる。

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Other

## How to Test

\`\`\`bash
go test -tags=integration ./...
go test ./...
\`\`\`

両方のテストがパスすることを確認。