### PR TITLE
refactor(cmd): simplify ListCommander injection pattern

### DIFF
--- a/cmd/gwt/main_test.go
+++ b/cmd/gwt/main_test.go
@@ -377,9 +377,7 @@ func TestListCmd(t *testing.T) {
 
 			mock := &mockListCommander{result: tt.result, err: tt.err}
 
-			cmd := newRootCmd(WithNewListCommander(func(dir string) ListCommander {
-				return mock
-			}))
+			cmd := newRootCmd(WithListCommander(mock))
 
 			stdout := &bytes.Buffer{}
 			stderr := &bytes.Buffer{}


### PR DESCRIPTION
## Overview

Simplify the command injection pattern for ListCommander.

## Why

Following the pattern established in #52 for AddCommander, the factory function pattern adds unnecessary indirection. Since tests only need to inject mock instances, we can simplify by directly injecting instances.

## What

- Remove `NewListCommander` type and `defaultNewListCommander` function
- Change `WithNewListCommander` to `WithListCommander` (takes instance directly)
- Update tests to use the simplified injection pattern

## Related

- #52 (AddCommander simplification)

## Type of Change

- [x] Refactoring

## How to Test

```bash
go test ./cmd/gwt/...
```