### PR TITLE
refactor(cmd): simplify CleanCommander injection pattern

### DIFF
--- a/cmd/gwt/main_test.go
+++ b/cmd/gwt/main_test.go
@@ -257,9 +257,7 @@ func TestCleanCmd(t *testing.T) {
 
 			mock := &mockCleanCommander{result: tt.result}
 
-			cmd := newRootCmd(WithNewCleanCommander(func(cfg *gwt.Config) CleanCommander {
-				return mock
-			}))
+			cmd := newRootCmd(WithCleanCommander(mock))
 
 			stdout := &bytes.Buffer{}
 			stderr := &bytes.Buffer{}


### PR DESCRIPTION
## Overview

Simplify the command injection pattern for CleanCommander.

## Why

Following the pattern established in #52 for AddCommander and #53 for ListCommander, the factory function pattern adds unnecessary indirection. Since tests only need to inject mock instances, we can simplify by directly injecting instances.

## What

- Remove `NewCleanCommander` type and `defaultNewCleanCommander` function
- Change `WithNewCleanCommander` to `WithCleanCommander` (takes instance directly)
- Update tests to use the simplified injection pattern

## Related

- #52 (AddCommander simplification)
- #53 (ListCommander simplification)

## Type of Change

- [x] Refactoring

## How to Test

```bash
go test ./cmd/gwt/...
```