### PR TITLE
chore: add install target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 .PHONY: build
 
+install:
+	go install ./cmd/gwt
+
 build:
 	go build -o out/gwt ./cmd/gwt


### PR DESCRIPTION
## Overview

Add `make install` command for convenient local installation.

## Why

Currently, installing gwt locally requires running `go install ./cmd/gwt` manually. Adding a Makefile target provides a more discoverable and consistent way to install the tool.

## What

- Add `install` target to Makefile that runs `go install ./cmd/gwt`

## Type of Change

- [x] Other

## How to Test

```bash
make install
gwt --help
```