### PR TITLE
chore: remove obsolete gwt symlink and add twig settings template

### DIFF
--- a/.gwt/settings.local.toml
+++ b/.gwt/settings.local.toml
@@ -1,1 +1,0 @@
-/Users/708u/ghq/github.com/708u/gwt/.gwt/settings.local.toml

--- a/.twig/settings.toml
+++ b/.twig/settings.toml
@@ -1,0 +1,15 @@
+# twig project configuration
+# See: https://github.com/708u/twig-worktree
+
+# Default source branch for new worktrees (prevents symlink chaining)
+default_source = "main"
+
+# Symlink patterns to create in new worktrees
+# Recommend: [".twig/settings.local.toml"] to share local settings across worktrees
+symlinks = []
+
+# Worktree destination base directory (default: ../<repo-name>-worktree)
+# worktree_destination_base_dir = "../my-worktrees"
+
+# Additional symlink patterns (collected from both project and local configs)
+# extra_symlinks = [".envrc", ".tool-versions"]


### PR DESCRIPTION
## Overview

Remove obsolete gwt configuration and add proper twig settings template.

## Why

After renaming gwt to twig in #61 , the old `.gwt/settings.local.toml`
symlink remained pointing to the pre-rename location. This cleanup removes
the obsolete symlink and adds a documented settings template.

## What

- Remove `.gwt/settings.local.toml` symlink (pointed to old gwt location)
- Add `.twig/settings.toml` with documented configuration options

## Related

- #61 (refactor: rename gwt to twig)

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [x] Other

## How to Test

1. Clone the repository
2. Verify `.gwt/settings.local.toml` no longer exists
3. Verify `.twig/settings.toml` contains the settings template