### PR TITLE
docs: add shell completion section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,34 @@ Requires Git 2.15+.
 go install github.com/708u/twig/cmd/twig@latest
 ```
 
+## Shell Completion
+
+Shell completion is available for all commands and flags.
+For example, `twig remove <TAB>` completes existing branch names.
+
+Add the following to your shell configuration:
+
+### Bash
+
+```bash
+# Add to ~/.bashrc
+eval "$(twig completion bash)"
+```
+
+### Zsh
+
+```bash
+# Add to ~/.zshrc
+eval "$(twig completion zsh)"
+```
+
+### Fish
+
+```sh
+# Add to ~/.config/fish/config.fish
+twig completion fish | source
+```
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Overview

Add shell completion setup instructions to README.

## Why

Shell completion improves CLI usability by enabling tab-completion for commands, flags, and branch names.

## What

- Add Shell Completion section to README
- Include setup instructions for Bash, Zsh, and Fish
- Add example showing branch name completion with `twig remove <TAB>`

## Type of Change

- [x] Documentation

## How to Test

1. Review the README changes
2. Follow the shell completion setup instructions for your shell
3. Verify `twig <TAB>` and `twig remove <TAB>` show completions