### PR TITLE
ci: add GitHub Actions workflow for goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
     tags:
       - "v*"
@@ -17,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Go
@@ -36,5 +35,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
-          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}


### PR DESCRIPTION
## Overview

Add GitHub Actions workflow for automated releases using goreleaser.

## Why

Automate the release process to create compiled binaries for multiple platforms
when a version tag is pushed.

## What

- Add `.github/workflows/release.yml` workflow
- Configure workflow to trigger only on `v*` tag pushes
- Set up goreleaser action to create releases with binaries
- Use actions/checkout@v6 and setup-go@v5

## Related

Related to #67 (goreleaser configuration)

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [x] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

1. Push a tag matching `v*` pattern (e.g., `v0.1.0`)
2. Verify GitHub Actions workflow runs successfully
3. Check that release is created with compiled binaries

## Checklist

- [x] Self-reviewed