### PR TITLE
ci: add Homebrew tap configuration for goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,12 @@ builds:
       - windows
       - darwin
 
+homebrew_casks:
+  - repository:
+      owner: 708u
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+
 archives:
   - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of `uname`.


### PR DESCRIPTION
## Overview

GoReleaserでHomebrew tapへの自動公開を設定

## Why

リリース時にHomebrewでのインストールを可能にするため、goreleaser経由でhomebrew-tapリポジトリにFormulaを自動公開する。

## What

- `.goreleaser.yaml`: `homebrew_casks`セクションを追加し、708u/homebrew-tapリポジトリへの公開設定
- `.github/workflows/release.yml`: クロスリポジトリアクセス用の`HOMEBREW_TAP_GITHUB_TOKEN`環境変数を追加

## Related

- #68 (goreleaser CI追加)

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [x] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

1. `HOMEBREW_TAP_GITHUB_TOKEN`シークレットをリポジトリに設定
2. タグをプッシュしてリリースワークフローを実行
3. 708u/homebrew-tapリポジトリにFormulaが作成されることを確認

## Checklist

- [x] Self-reviewed