### PR TITLE
fix: add xattr hook to remove quarantine attribute on macOS

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,12 @@ homebrew_casks:
       owner: 708u
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/twig"]
+          end
 
 archives:
   - formats: [tar.gz]


### PR DESCRIPTION
## Overview

Homebrew caskのpost install hookを追加し、macOSのquarantine属性を削除する

## Why

Homebrew経由でインストールしたバイナリにGatekeeperの警告が表示される問題を解決するため

## What

- `.goreleaser.yaml` にHomebrew caskのpost install hookを追加
- macOSでのみ `xattr -dr com.apple.quarantine` を実行してquarantine属性を削除

## Related

- #69

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

1. リリースワークフローを実行してHomebrew tapを更新
2. `brew install 708u/tap/twig` でインストール
3. Gatekeeperの警告が表示されないことを確認

## Checklist

- [x] Self-reviewed