### PR TITLE
docs: add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Examples:
 
 Requires Git 2.15+.
 
+### Homebrew
+
+```bash
+brew install 708u/tap/twig
+```
+
+### Go
+
 ```bash
 go install github.com/708u/twig/cmd/twig@latest
 ```


### PR DESCRIPTION
## Overview

READMEにHomebrew経由のインストール方法を追記

## Why

goreleaserでHomebrew tap設定を追加したため（ #69 ）、READMEにもインストール方法を記載する

## What

- READMEのInstallationセクションにHomebrewサブセクションを追加
- `brew install 708u/tap/twig` コマンドを記載
- 既存のgo installをGoサブセクションとして整理

## Related

- #69 

## Type of Change

- [x] Documentation

## How to Test

1. READMEのInstallationセクションを確認
2. Homebrewのインストールコマンドが正しく記載されていることを確認

## Checklist

- [x] Self-reviewed