### PR TITLE
fix: add LICENSE, README, and completion scripts to release archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,6 +44,10 @@ homebrew_casks:
 
 archives:
   - formats: [tar.gz]
+    files:
+      - LICENSE
+      - README.md
+      - completion/*
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_


### PR DESCRIPTION
## Overview

Add documentation and shell completion scripts to release archives.

## Why

Release archives currently only contain the binary. Users who download the
release archive don't have access to the LICENSE, README, or shell completion
scripts that would help them use twig effectively.

## What

- Add `files` field to goreleaser archives configuration
- Include LICENSE, README.md, and completion/* in tar.gz archives

## Related

<!-- N/A -->

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

1. Run `goreleaser release --snapshot --clean`
2. Check the generated tar.gz archive contains LICENSE, README.md, and completion scripts

## Checklist

<!-- - [ ] Tests added/updated -->
<!-- - [ ] Self-reviewed -->