### PR TITLE
fix(remove): handle prunable worktrees when directory is deleted externally

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@
 A CLI tool that creates, deletes, and manages git worktrees and branches in a single command.
 Focused on simplifying git operations, keeping features minimal.
 
+## Design Philosophy
+
+twig treats branches and worktrees as a single unified concept.
+Users don't need to think about whether they're managing a "branch" or a "worktree" -
+they simply work with named development contexts.
+
+- `twig add feat/x` creates both the branch and worktree together
+- `twig remove feat/x` deletes both together
+- Even if a worktree directory is deleted externally, `twig remove` still works
+
+This 1:1 mapping simplifies the mental model: one name, one workspace, one command.
+
 ## Motivation
 
 twig is designed to be friendly for both humans and agentic coding tools,

--- a/clean_integration_test.go
+++ b/clean_integration_test.go
@@ -294,9 +294,10 @@ func TestCleanCommand_Integration(t *testing.T) {
 			t.Errorf("expected 1 removed, got %d", len(result.Removed))
 		}
 
-		// Prune should be called
-		if !result.Pruned {
-			t.Error("prune should have been called")
+		// For normal (non-prunable) worktrees, Pruned should be false
+		// Prune is only called for prunable worktrees via RemoveCommand
+		if result.Pruned {
+			t.Error("pruned should be false for normal worktree removal")
 		}
 	})
 
@@ -436,6 +437,11 @@ func TestCleanCommand_Integration(t *testing.T) {
 		out := testutil.RunGit(t, mainDir, "branch", "--list", "feature/clean-prunable")
 		if strings.TrimSpace(out) != "" {
 			t.Errorf("prunable branch should be deleted, got: %s", out)
+		}
+
+		// Pruned should be true when prunable branches were processed
+		if !result.Pruned {
+			t.Error("pruned should be true when prunable branches are cleaned")
 		}
 	})
 

--- a/cmd/twig/main.go
+++ b/cmd/twig/main.go
@@ -94,11 +94,11 @@ func resolveCarryFrom(carryValue, originalCwd string, git *twig.GitRunner) (stri
 	case "":
 		return "", fmt.Errorf("carry value cannot be empty")
 	default:
-		path, err := git.WorktreeFindByBranch(carryValue)
+		wt, err := git.WorktreeFindByBranch(carryValue)
 		if err != nil {
 			return "", fmt.Errorf("failed to find worktree for branch %q: %w", carryValue, err)
 		}
-		return path, nil
+		return wt.Path, nil
 	}
 }
 
@@ -233,13 +233,13 @@ With --carry, use --file to carry only matching files:
 
 			// Resolve branch to worktree path
 			git := twig.NewGitRunner(cwd)
-			sourcePath, err := git.WorktreeFindByBranch(source)
+			sourceWT, err := git.WorktreeFindByBranch(source)
 			if err != nil {
 				return fmt.Errorf("failed to find worktree for branch %q: %w", source, err)
 			}
 
 			// Load config from source worktree
-			cwd = sourcePath
+			cwd = sourceWT.Path
 			result, err := twig.LoadConfig(cwd)
 			if err != nil {
 				return fmt.Errorf("failed to load config: %w", err)
@@ -519,8 +519,8 @@ stop processing of remaining branches.`,
 		// If --source is specified, resolve to that worktree
 		if source, _ := cmd.Flags().GetString("source"); source != "" {
 			git := twig.NewGitRunner(dir)
-			if sourcePath, err := git.WorktreeFindByBranch(source); err == nil {
-				dir = sourcePath
+			if sourceWT, err := git.WorktreeFindByBranch(source); err == nil {
+				dir = sourceWT.Path
 			}
 		}
 

--- a/cmd/twig/main_integration_test.go
+++ b/cmd/twig/main_integration_test.go
@@ -46,13 +46,13 @@ func TestAddCommand_SourceFlag_Integration(t *testing.T) {
 		// Now simulate --source main from feat/a worktree
 		// The PreRunE logic: resolve main branch to its worktree path, then reload config
 		git := twig.NewGitRunner(featAPath)
-		mainPath, err := git.WorktreeFindByBranch("main")
+		mainWT, err := git.WorktreeFindByBranch("main")
 		if err != nil {
 			t.Fatalf("failed to find main worktree: %v", err)
 		}
 
 		// Load config from main (as --source would do)
-		result, err = twig.LoadConfig(mainPath)
+		result, err = twig.LoadConfig(mainWT.Path)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -104,13 +104,13 @@ func TestAddCommand_SourceFlag_Integration(t *testing.T) {
 		// Simulate -C pointing to mainDir and --source pointing to main
 		// This should work: -C sets working directory, --source sets source branch
 		git := twig.NewGitRunner(mainDir)
-		sourcePath, err := git.WorktreeFindByBranch("main")
+		sourceWT, err := git.WorktreeFindByBranch("main")
 		if err != nil {
 			t.Fatalf("failed to find main worktree: %v", err)
 		}
 
 		// Load config from source (as --source would do after -C sets cwd)
-		result, err := twig.LoadConfig(sourcePath)
+		result, err := twig.LoadConfig(sourceWT.Path)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -221,13 +221,13 @@ func TestAddCommand_DefaultSource_Integration(t *testing.T) {
 		// When default_source is applied, config should be reloaded from main
 		// Simulate the PreRunE logic
 		git := twig.NewGitRunner(featAPath)
-		mainPath, err := git.WorktreeFindByBranch(resultFeatA.Config.DefaultSource)
+		mainWT, err := git.WorktreeFindByBranch(resultFeatA.Config.DefaultSource)
 		if err != nil {
 			t.Fatalf("failed to find worktree for default_source: %v", err)
 		}
 
 		// Load config from main (as default_source would do)
-		resultMain, err := twig.LoadConfig(mainPath)
+		resultMain, err := twig.LoadConfig(mainWT.Path)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/docs/commands/remove.md
+++ b/docs/commands/remove.md
@@ -34,6 +34,27 @@ twig remove <branch>... [flags]
 This matches git's behavior where `git worktree remove -f` removes unclean
 worktrees and `git worktree remove -f -f` also removes locked worktrees.
 
+### Prunable Worktrees
+
+When a worktree directory is deleted externally (via `rm -rf` or other means),
+the branch remains but the worktree becomes "prunable". The remove command
+handles this gracefully:
+
+```bash
+# Worktree deleted externally
+rm -rf /path/to/feat/x
+
+# twig remove still works - prunes the stale record and deletes the branch
+twig remove feat/x
+```
+
+For prunable worktrees:
+
+- Stale worktree records are pruned automatically
+- Branch is deleted as usual
+- No cwd check is performed (directory doesn't exist)
+- `--dry-run` shows "Would prune stale worktree record"
+
 ### Empty Directory Cleanup
 
 After removing a worktree, twig automatically removes any empty parent

--- a/git.go
+++ b/git.go
@@ -307,34 +307,21 @@ func (g *GitRunner) WorktreeListBranches() ([]string, error) {
 	return branches, nil
 }
 
-// WorktreeFindByBranch returns the worktree path for the given branch.
+// WorktreeFindByBranch returns the WorktreeInfo for the given branch.
 // Returns an error if the branch is not checked out in any worktree.
-func (g *GitRunner) WorktreeFindByBranch(branch string) (string, error) {
-	out, err := g.worktreeListPorcelain()
+func (g *GitRunner) WorktreeFindByBranch(branch string) (*WorktreeInfo, error) {
+	worktrees, err := g.WorktreeList()
 	if err != nil {
-		return "", fmt.Errorf("failed to list worktrees: %w", err)
+		return nil, err
 	}
 
-	// porcelain format:
-	// worktree /path/to/worktree
-	// HEAD abc123
-	// branch refs/heads/branch-name
-	// (blank line)
-
-	lines := strings.Split(string(out), "\n")
-	var currentPath string
-	for _, line := range lines {
-		if path, ok := strings.CutPrefix(line, PorcelainWorktreePrefix); ok {
-			currentPath = path
-		}
-		if branchName, ok := strings.CutPrefix(line, PorcelainBranchPrefix); ok {
-			if branchName == branch {
-				return currentPath, nil
-			}
+	for i := range worktrees {
+		if worktrees[i].Branch == branch {
+			return &worktrees[i], nil
 		}
 	}
 
-	return "", fmt.Errorf("branch %q is not checked out in any worktree", branch)
+	return nil, fmt.Errorf("branch %q is not checked out in any worktree", branch)
 }
 
 // WorktreeForceLevel represents the force level for worktree removal.

--- a/git_integration_test.go
+++ b/git_integration_test.go
@@ -28,8 +28,8 @@ func TestGitRunner_WorktreeFindByBranch_Integration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got != wtPath {
-			t.Errorf("got %q, want %q", got, wtPath)
+		if got.Path != wtPath {
+			t.Errorf("got %q, want %q", got.Path, wtPath)
 		}
 	})
 


### PR DESCRIPTION
## Overview

`twig remove` がprunable worktree（ディレクトリが外部削除されたworktree）を
正しく処理できるようにする修正。

## Why

ユーザーが `rm -rf` などでworktreeディレクトリを直接削除した場合、
`twig remove` が失敗していた。twigの設計思想として、branchとworktreeは
1:1の統一概念であり、ユーザーは内部状態を意識せずに操作できるべき。

## What

- `RemoveCommand` がprunable worktreeを検出・処理するよう変更
- `WorktreeFindByBranch` を `*WorktreeInfo` を返すよう統合
  （`WorktreeFindByBranchFull` を削除）
- `CleanCommand` のprunable専用処理を削除し、`RemoveCommand` に委譲
- `RemovedWorktree.Pruned` フィールドを追加
- README.mdにDesign Philosophyセクションを追加
- docs/commands/remove.mdにPrunable Worktreesセクションを追加

## Type of Change

- [x] Bug fix
- [x] Documentation

## How to Test

```bash
# 統合テストを実行
go test -tags=integration ./...

# 手動テスト
twig add feat/test
rm -rf <worktree-path>
twig remove feat/test  # 正常に動作することを確認
```

## Checklist

- [x] Tests added/updated
- [x] Self-reviewed