### PR TITLE
refactor: rename WorktreeInfo to Worktree

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -270,7 +270,7 @@ func (c *CleanCommand) resolveTarget(target string) (string, error) {
 
 // checkSkipReason checks if worktree should be skipped and returns the reason.
 // force level controls which conditions can be bypassed (matches git worktree behavior).
-func (c *CleanCommand) checkSkipReason(wt WorktreeInfo, cwd, target string, force WorktreeForceLevel) SkipReason {
+func (c *CleanCommand) checkSkipReason(wt Worktree, cwd, target string, force WorktreeForceLevel) SkipReason {
 	// Check detached HEAD (never bypassed)
 	if wt.Detached {
 		return SkipDetached

--- a/clean_test.go
+++ b/clean_test.go
@@ -669,7 +669,7 @@ func TestCleanCommand_CheckSkipReason(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		wt         WorktreeInfo
+		wt         Worktree
 		cwd        string
 		target     string
 		force      WorktreeForceLevel
@@ -679,7 +679,7 @@ func TestCleanCommand_CheckSkipReason(t *testing.T) {
 		// Basic cases (no force)
 		{
 			name:   "no_skip_for_valid_candidate",
-			wt:     WorktreeInfo{Path: "/repo/feat/a", Branch: "feat/a"},
+			wt:     Worktree{Path: "/repo/feat/a", Branch: "feat/a"},
 			cwd:    "/other/dir",
 			target: "main",
 			force:  WorktreeForceLevelNone,
@@ -694,7 +694,7 @@ func TestCleanCommand_CheckSkipReason(t *testing.T) {
 		},
 		{
 			name:       "skip_detached",
-			wt:         WorktreeInfo{Path: "/repo/feat/a", Detached: true},
+			wt:         Worktree{Path: "/repo/feat/a", Detached: true},
 			cwd:        "/other/dir",
 			target:     "main",
 			force:      WorktreeForceLevelNone,
@@ -703,7 +703,7 @@ func TestCleanCommand_CheckSkipReason(t *testing.T) {
 		},
 		{
 			name:       "skip_locked",
-			wt:         WorktreeInfo{Path: "/repo/feat/a", Branch: "feat/a", Locked: true},
+			wt:         Worktree{Path: "/repo/feat/a", Branch: "feat/a", Locked: true},
 			cwd:        "/other/dir",
 			target:     "main",
 			force:      WorktreeForceLevelNone,
@@ -712,7 +712,7 @@ func TestCleanCommand_CheckSkipReason(t *testing.T) {
 		},
 		{
 			name:       "skip_current_dir",
-			wt:         WorktreeInfo{Path: "/repo/feat/a", Branch: "feat/a"},
+			wt:         Worktree{Path: "/repo/feat/a", Branch: "feat/a"},
 			cwd:        "/repo/feat/a/subdir",
 			target:     "main",
 			force:      WorktreeForceLevelNone,
@@ -721,7 +721,7 @@ func TestCleanCommand_CheckSkipReason(t *testing.T) {
 		},
 		{
 			name:   "skip_has_changes",
-			wt:     WorktreeInfo{Path: "/repo/feat/a", Branch: "feat/a"},
+			wt:     Worktree{Path: "/repo/feat/a", Branch: "feat/a"},
 			cwd:    "/other/dir",
 			target: "main",
 			force:  WorktreeForceLevelNone,
@@ -734,7 +734,7 @@ func TestCleanCommand_CheckSkipReason(t *testing.T) {
 		},
 		{
 			name:   "skip_not_merged",
-			wt:     WorktreeInfo{Path: "/repo/feat/a", Branch: "feat/a"},
+			wt:     Worktree{Path: "/repo/feat/a", Branch: "feat/a"},
 			cwd:    "/other/dir",
 			target: "main",
 			force:  WorktreeForceLevelNone,
@@ -750,7 +750,7 @@ func TestCleanCommand_CheckSkipReason(t *testing.T) {
 		// Force level: Unclean (-f)
 		{
 			name:   "force_unclean_bypasses_has_changes",
-			wt:     WorktreeInfo{Path: "/repo/feat/a", Branch: "feat/a"},
+			wt:     Worktree{Path: "/repo/feat/a", Branch: "feat/a"},
 			cwd:    "/other/dir",
 			target: "main",
 			force:  WorktreeForceLevelUnclean,
@@ -763,7 +763,7 @@ func TestCleanCommand_CheckSkipReason(t *testing.T) {
 		},
 		{
 			name:   "force_unclean_bypasses_not_merged",
-			wt:     WorktreeInfo{Path: "/repo/feat/a", Branch: "feat/a"},
+			wt:     Worktree{Path: "/repo/feat/a", Branch: "feat/a"},
 			cwd:    "/other/dir",
 			target: "main",
 			force:  WorktreeForceLevelUnclean,
@@ -778,7 +778,7 @@ func TestCleanCommand_CheckSkipReason(t *testing.T) {
 		},
 		{
 			name:       "force_unclean_does_not_bypass_locked",
-			wt:         WorktreeInfo{Path: "/repo/feat/a", Branch: "feat/a", Locked: true},
+			wt:         Worktree{Path: "/repo/feat/a", Branch: "feat/a", Locked: true},
 			cwd:        "/other/dir",
 			target:     "main",
 			force:      WorktreeForceLevelUnclean,
@@ -788,7 +788,7 @@ func TestCleanCommand_CheckSkipReason(t *testing.T) {
 		// Force level: Locked (-ff)
 		{
 			name:       "force_locked_bypasses_locked",
-			wt:         WorktreeInfo{Path: "/repo/feat/a", Branch: "feat/a", Locked: true},
+			wt:         Worktree{Path: "/repo/feat/a", Branch: "feat/a", Locked: true},
 			cwd:        "/other/dir",
 			target:     "main",
 			force:      WorktreeForceLevelLocked,
@@ -797,7 +797,7 @@ func TestCleanCommand_CheckSkipReason(t *testing.T) {
 		},
 		{
 			name:   "force_locked_bypasses_has_changes",
-			wt:     WorktreeInfo{Path: "/repo/feat/a", Branch: "feat/a"},
+			wt:     Worktree{Path: "/repo/feat/a", Branch: "feat/a"},
 			cwd:    "/other/dir",
 			target: "main",
 			force:  WorktreeForceLevelLocked,
@@ -811,7 +811,7 @@ func TestCleanCommand_CheckSkipReason(t *testing.T) {
 		// Never bypassed (even with -ff)
 		{
 			name:       "force_locked_does_not_bypass_detached",
-			wt:         WorktreeInfo{Path: "/repo/feat/a", Detached: true},
+			wt:         Worktree{Path: "/repo/feat/a", Detached: true},
 			cwd:        "/other/dir",
 			target:     "main",
 			force:      WorktreeForceLevelLocked,
@@ -820,7 +820,7 @@ func TestCleanCommand_CheckSkipReason(t *testing.T) {
 		},
 		{
 			name:       "force_locked_does_not_bypass_current_dir",
-			wt:         WorktreeInfo{Path: "/repo/feat/a", Branch: "feat/a"},
+			wt:         Worktree{Path: "/repo/feat/a", Branch: "feat/a"},
 			cwd:        "/repo/feat/a/subdir",
 			target:     "main",
 			force:      WorktreeForceLevelLocked,

--- a/cmd/twig/main_test.go
+++ b/cmd/twig/main_test.go
@@ -316,7 +316,7 @@ func TestListCmd(t *testing.T) {
 			name: "default output",
 			args: []string{"list"},
 			result: twig.ListResult{
-				Worktrees: []twig.WorktreeInfo{
+				Worktrees: []twig.Worktree{
 					{Path: "/repo/main", Branch: "main", HEAD: "abc1234567890"},
 					{Path: "/repo/feat-a", Branch: "feat/a", HEAD: "def5678901234"},
 				},
@@ -327,7 +327,7 @@ func TestListCmd(t *testing.T) {
 			name: "quiet flag outputs paths only",
 			args: []string{"list", "--quiet"},
 			result: twig.ListResult{
-				Worktrees: []twig.WorktreeInfo{
+				Worktrees: []twig.Worktree{
 					{Path: "/repo/main", Branch: "main", HEAD: "abc1234567890"},
 					{Path: "/repo/feat-a", Branch: "feat/a", HEAD: "def5678901234"},
 				},
@@ -338,7 +338,7 @@ func TestListCmd(t *testing.T) {
 			name: "short flag -q",
 			args: []string{"list", "-q"},
 			result: twig.ListResult{
-				Worktrees: []twig.WorktreeInfo{
+				Worktrees: []twig.Worktree{
 					{Path: "/repo/main", Branch: "main", HEAD: "abc1234567890"},
 				},
 			},
@@ -348,7 +348,7 @@ func TestListCmd(t *testing.T) {
 			name: "empty list",
 			args: []string{"list"},
 			result: twig.ListResult{
-				Worktrees: []twig.WorktreeInfo{},
+				Worktrees: []twig.Worktree{},
 			},
 			wantStdout: "",
 		},

--- a/git.go
+++ b/git.go
@@ -221,8 +221,8 @@ func (g *GitRunner) BranchList() ([]string, error) {
 	return branches, nil
 }
 
-// WorktreeInfo holds worktree path and branch information.
-type WorktreeInfo struct {
+// Worktree holds worktree path and branch information.
+type Worktree struct {
 	Path           string
 	Branch         string
 	HEAD           string
@@ -235,7 +235,7 @@ type WorktreeInfo struct {
 }
 
 // ShortHEAD returns the first 7 characters of the HEAD commit hash.
-func (w WorktreeInfo) ShortHEAD() string {
+func (w Worktree) ShortHEAD() string {
 	if len(w.HEAD) >= 7 {
 		return w.HEAD[:7]
 	}
@@ -243,7 +243,7 @@ func (w WorktreeInfo) ShortHEAD() string {
 }
 
 // WorktreeList returns all worktrees with their paths and branches.
-func (g *GitRunner) WorktreeList() ([]WorktreeInfo, error) {
+func (g *GitRunner) WorktreeList() ([]Worktree, error) {
 	out, err := g.worktreeListPorcelain()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list worktrees: %w", err)
@@ -259,12 +259,12 @@ func (g *GitRunner) WorktreeList() ([]WorktreeInfo, error) {
 	// prunable [reason] (optional)
 	// (blank line)
 
-	var worktrees []WorktreeInfo
-	var current WorktreeInfo
+	var worktrees []Worktree
+	var current Worktree
 	for _, line := range strings.Split(string(out), "\n") {
 		switch {
 		case strings.HasPrefix(line, PorcelainWorktreePrefix):
-			current = WorktreeInfo{Path: strings.TrimPrefix(line, PorcelainWorktreePrefix)}
+			current = Worktree{Path: strings.TrimPrefix(line, PorcelainWorktreePrefix)}
 		case strings.HasPrefix(line, PorcelainHEADPrefix):
 			current.HEAD = strings.TrimPrefix(line, PorcelainHEADPrefix)
 		case strings.HasPrefix(line, PorcelainBranchPrefix):
@@ -285,7 +285,7 @@ func (g *GitRunner) WorktreeList() ([]WorktreeInfo, error) {
 			}
 		case line == "" && current.Path != "":
 			worktrees = append(worktrees, current)
-			current = WorktreeInfo{}
+			current = Worktree{}
 		}
 	}
 	return worktrees, nil
@@ -307,9 +307,9 @@ func (g *GitRunner) WorktreeListBranches() ([]string, error) {
 	return branches, nil
 }
 
-// WorktreeFindByBranch returns the WorktreeInfo for the given branch.
+// WorktreeFindByBranch returns the Worktree for the given branch.
 // Returns an error if the branch is not checked out in any worktree.
-func (g *GitRunner) WorktreeFindByBranch(branch string) (*WorktreeInfo, error) {
+func (g *GitRunner) WorktreeFindByBranch(branch string) (*Worktree, error) {
 	worktrees, err := g.WorktreeList()
 	if err != nil {
 		return nil, err

--- a/list.go
+++ b/list.go
@@ -26,7 +26,7 @@ func NewDefaultListCommand(dir string) *ListCommand {
 
 // ListResult holds the result of a list operation.
 type ListResult struct {
-	Worktrees []WorktreeInfo
+	Worktrees []Worktree
 }
 
 // ListFormatOptions configures list output formatting.
@@ -66,7 +66,7 @@ func (r ListResult) formatDefault() FormatResult {
 }
 
 // formatStatus returns the status portion of the worktree line (branch, locked, prunable).
-func (w WorktreeInfo) formatStatus() string {
+func (w Worktree) formatStatus() string {
 	var sb strings.Builder
 
 	if w.Bare {

--- a/list_integration_test.go
+++ b/list_integration_test.go
@@ -116,7 +116,7 @@ func TestListCommand_Integration(t *testing.T) {
 		}
 	})
 
-	t.Run("WorktreeInfoHasHEAD", func(t *testing.T) {
+	t.Run("WorktreeHasHEAD", func(t *testing.T) {
 		t.Parallel()
 
 		_, mainDir := testutil.SetupTestRepo(t)

--- a/list_test.go
+++ b/list_test.go
@@ -102,13 +102,13 @@ func TestListResult_Format(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		worktrees  []WorktreeInfo
+		worktrees  []Worktree
 		opts       ListFormatOptions
 		wantStdout string
 	}{
 		{
 			name: "git worktree list compatible format",
-			worktrees: []WorktreeInfo{
+			worktrees: []Worktree{
 				{Path: "/repo/main", Branch: "main", HEAD: "abc1234567890"},
 				{Path: "/repo/worktree/feat-a", Branch: "feat/a", HEAD: "def5678901234"},
 			},
@@ -116,40 +116,40 @@ func TestListResult_Format(t *testing.T) {
 		},
 		{
 			name: "detached HEAD",
-			worktrees: []WorktreeInfo{
+			worktrees: []Worktree{
 				{Path: "/repo/worktree/detached", HEAD: "abc1234567890", Detached: true},
 			},
 			wantStdout: "/repo/worktree/detached  abc1234 (detached HEAD)\n",
 		},
 		{
 			name: "locked worktree",
-			worktrees: []WorktreeInfo{
+			worktrees: []Worktree{
 				{Path: "/repo/worktree/locked", Branch: "locked-branch", HEAD: "abc1234567890", Locked: true},
 			},
 			wantStdout: "/repo/worktree/locked  abc1234 [locked-branch] locked\n",
 		},
 		{
 			name: "prunable worktree",
-			worktrees: []WorktreeInfo{
+			worktrees: []Worktree{
 				{Path: "/repo/worktree/prunable", HEAD: "abc1234567890", Detached: true, Prunable: true},
 			},
 			wantStdout: "/repo/worktree/prunable  abc1234 (detached HEAD) prunable\n",
 		},
 		{
 			name: "bare repository",
-			worktrees: []WorktreeInfo{
+			worktrees: []Worktree{
 				{Path: "/repo/bare", HEAD: "abc1234567890", Bare: true},
 			},
 			wantStdout: "/repo/bare  abc1234 (bare)\n",
 		},
 		{
 			name:       "empty list",
-			worktrees:  []WorktreeInfo{},
+			worktrees:  []Worktree{},
 			wantStdout: "",
 		},
 		{
 			name: "quiet format outputs paths only",
-			worktrees: []WorktreeInfo{
+			worktrees: []Worktree{
 				{Path: "/repo/main", Branch: "main", HEAD: "abc1234567890"},
 				{Path: "/repo/worktree/feat-a", Branch: "feat/a", HEAD: "def5678901234"},
 			},
@@ -158,7 +158,7 @@ func TestListResult_Format(t *testing.T) {
 		},
 		{
 			name:       "quiet format with empty list",
-			worktrees:  []WorktreeInfo{},
+			worktrees:  []Worktree{},
 			opts:       ListFormatOptions{Quiet: true},
 			wantStdout: "",
 		},
@@ -178,7 +178,7 @@ func TestListResult_Format(t *testing.T) {
 	}
 }
 
-func TestWorktreeInfo_ShortHEAD(t *testing.T) {
+func TestWorktree_ShortHEAD(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -207,7 +207,7 @@ func TestWorktreeInfo_ShortHEAD(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			wt := WorktreeInfo{HEAD: tt.head}
+			wt := Worktree{HEAD: tt.head}
 			if got := wt.ShortHEAD(); got != tt.want {
 				t.Errorf("ShortHEAD() = %q, want %q", got, tt.want)
 			}


### PR DESCRIPTION
## Overview

Rename `WorktreeInfo` type to `Worktree` for better Go naming conventions.

## Why

The `Info` suffix in `WorktreeInfo` is redundant. Go style prefers simpler, more direct names.

## What

- Renamed `WorktreeInfo` struct to `Worktree` in `git.go`
- Updated all usages in `list.go`, `clean.go`
- Updated test files: `list_test.go`, `clean_test.go`, `cmd/twig/main_test.go`, `list_integration_test.go`
- Renamed test function `TestWorktreeInfo_ShortHEAD` to `TestWorktree_ShortHEAD`
- Renamed integration test `WorktreeInfoHasHEAD` to `WorktreeHasHEAD`

## Related

N/A

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

```bash
go test -tags=integration ./...
```

## Checklist

- [x] Tests pass
- [x] Self-reviewed