### PR TITLE
chore: add symlink patterns for local settings and mcp config

### DIFF
--- a/.twig/settings.toml
+++ b/.twig/settings.toml
@@ -6,7 +6,7 @@ default_source = "main"
 
 # Symlink patterns to create in new worktrees
 # Recommend: [".twig/settings.local.toml"] to share local settings across worktrees
-symlinks = [".claude/user_instructions"]
+symlinks = [".claude/user_instructions", ".claude/settings.local.json", ".twig/settings.local.toml", ".mcp.json"]
 
 # Worktree destination base directory (default: ../<repo-name>-worktree)
 # worktree_destination_base_dir = "../my-worktrees"


### PR DESCRIPTION
## Overview

Add additional symlink patterns to default configuration for better worktree setup.

## Why

Local settings and MCP configuration files should be shared across worktrees
to maintain consistent development environment.

## What

- Add `.claude/settings.local.json` to symlinks
- Add `.twig/settings.local.toml` to symlinks
- Add `.mcp.json` to symlinks

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [x] Other

## How to Test

1. Run `twig init` to create new configuration
2. Verify `.twig/settings.toml` contains updated symlinks patterns
3. Create a new worktree with `twig add test-branch`
4. Verify symlinks are created for the specified patterns