### PR TITLE
perf(add): use local refs instead of ls-remote for remote branch detection

### DIFF
--- a/add_integration_test.go
+++ b/add_integration_test.go
@@ -1319,6 +1319,10 @@ worktree_destination_base_dir = %q
 			t.Fatal("feature/remote-only should not exist locally before test")
 		}
 
+		// Fetch from origin to get remote-tracking branches
+		// (like git checkout, twig checks local remote-tracking refs)
+		testutil.RunGit(t, mainDir, "fetch", "origin")
+
 		cmd := &AddCommand{
 			FS:     osFS{},
 			Git:    NewGitRunner(mainDir),

--- a/docs/commands/add.md
+++ b/docs/commands/add.md
@@ -38,25 +38,32 @@ twig add <name> [flags]
 
 ### Remote Branch Support
 
-When the specified branch doesn't exist locally, twig automatically checks
-configured remotes:
+When the specified branch doesn't exist locally, twig checks local
+remote-tracking branches (e.g., `refs/remotes/origin/<branch>`):
 
 ```bash
-# If origin/feat/api exists but local feat/api doesn't:
+# If origin/feat/api exists locally (already fetched):
 twig add feat/api
-# Fetches from origin and creates worktree with tracking branch
+# Creates worktree with tracking branch
 ```
 
 This behavior is similar to `git checkout <branch>` which auto-tracks
-remote branches.
+remote branches without network access.
+
+To get the latest remote branches, run `git fetch` first:
+
+```bash
+git fetch origin
+twig add feat/api
+```
 
 #### Multiple Remotes
 
-When multiple remotes are configured:
+When multiple remotes have the branch:
 
 | Scenario                              | Behavior                            |
 |---------------------------------------|-------------------------------------|
-| Branch exists on one remote only      | Fetches from that remote            |
+| Branch exists on one remote only      | Uses that remote                    |
 | Branch exists on multiple remotes     | Error (ambiguous)                   |
 | Branch exists on no remote            | Creates new local branch            |
 
@@ -64,16 +71,6 @@ When multiple remotes are configured:
 # Branch exists on both origin and upstream
 twig add feat/shared
 # Error: branch "feat/shared" exists on multiple remotes: [origin upstream]
-```
-
-#### Fetch Errors
-
-If fetching fails (network error, authentication, etc.), the error is
-displayed with context:
-
-```bash
-twig add feat/api
-# Error: failed to fetch feat/api from origin: <git error message>
 ```
 
 ### Sync Option

--- a/internal/testutil/mock_git.go
+++ b/internal/testutil/mock_git.go
@@ -74,14 +74,11 @@ type MockGitExecutor struct {
 	Remotes []string
 
 	// RemoteBranches maps remote name to list of branches on that remote.
-	// Used by ls-remote to check if a branch exists on a remote.
+	// Used by for-each-ref to check local remote-tracking branches.
 	RemoteBranches map[string][]string
 
 	// FetchErr is returned when fetch is called.
 	FetchErr error
-
-	// LsRemoteErr is returned when ls-remote fails (e.g., network error).
-	LsRemoteErr error
 }
 
 func (m *MockGitExecutor) Run(args ...string) ([]byte, error) {
@@ -125,10 +122,6 @@ func (m *MockGitExecutor) defaultRun(args ...string) ([]byte, error) {
 		return m.handleStash(args)
 	case "for-each-ref":
 		return m.handleForEachRef(args)
-	case "remote":
-		return m.handleRemote(args)
-	case "ls-remote":
-		return m.handleLsRemote(args)
 	case "fetch":
 		return m.handleFetch(args)
 	}
@@ -286,57 +279,36 @@ func (m *MockGitExecutor) handleStash(args []string) ([]byte, error) {
 }
 
 func (m *MockGitExecutor) handleForEachRef(args []string) ([]byte, error) {
-	// args: ["for-each-ref", "--format=%(upstream:track)", "refs/heads/<branch>"]
 	if len(args) < 3 {
 		return nil, nil
 	}
 
 	ref := args[2]
-	branch, ok := strings.CutPrefix(ref, "refs/heads/")
-	if !ok {
-		return nil, nil
+
+	// Handle refs/heads/<branch> for upstream tracking check
+	if branch, ok := strings.CutPrefix(ref, "refs/heads/"); ok {
+		if slices.Contains(m.UpstreamGoneBranches, branch) {
+			return []byte("[gone]\n"), nil
+		}
+		return []byte("\n"), nil
 	}
 
-	if slices.Contains(m.UpstreamGoneBranches, branch) {
-		return []byte("[gone]\n"), nil
-	}
-	return []byte("\n"), nil
-}
-
-func (m *MockGitExecutor) handleRemote(args []string) ([]byte, error) {
-	// args: ["remote"]
-	if len(m.Remotes) == 0 {
-		return []byte{}, nil
-	}
-	return []byte(strings.Join(m.Remotes, "\n") + "\n"), nil
-}
-
-func (m *MockGitExecutor) handleLsRemote(args []string) ([]byte, error) {
-	// args: ["ls-remote", "--heads", "remote", "refs/heads/<branch>"]
-	if m.LsRemoteErr != nil {
-		return nil, m.LsRemoteErr
-	}
-	if len(args) < 4 {
-		return nil, nil
-	}
-
-	remote := args[2]
-	ref := args[3]
-	branch, ok := strings.CutPrefix(ref, "refs/heads/")
-	if !ok {
-		return nil, nil
-	}
-
-	branches, exists := m.RemoteBranches[remote]
-	if !exists {
+	// Handle refs/remotes/*/<branch> for remote branch detection
+	if strings.HasPrefix(ref, "refs/remotes/*/") {
+		branch := strings.TrimPrefix(ref, "refs/remotes/*/")
+		var results []string
+		for remote, branches := range m.RemoteBranches {
+			if slices.Contains(branches, branch) {
+				results = append(results, remote+"/"+branch)
+			}
+		}
+		if len(results) > 0 {
+			return []byte(strings.Join(results, "\n") + "\n"), nil
+		}
 		return []byte{}, nil
 	}
 
-	if slices.Contains(branches, branch) {
-		// Return fake hash and ref like real ls-remote output
-		return []byte("abc123def456\trefs/heads/" + branch + "\n"), nil
-	}
-	return []byte{}, nil
+	return nil, nil
 }
 
 func (m *MockGitExecutor) handleFetch(args []string) ([]byte, error) {


### PR DESCRIPTION
## Overview

Improve remote branch detection performance by eliminating network access.

## Why

The previous implementation used `git ls-remote` which requires network access for each remote, causing delays and potential failures in offline scenarios.

## What

- Switch `FindRemotesForBranch` from `ls-remote` to `for-each-ref` on local refs
- Check `refs/remotes/*/<branch>` locally without network access
- Remove unused `GitCmdRemote` and `GitCmdLsRemote` constants
- Update mock implementation to handle local ref-based detection
- Update documentation to clarify the behavior matches `git checkout`

## Related

Follow-up to #85

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [x] Performance
- [ ] Other

## How to Test

```bash
# Run integration tests
go test -tags=integration ./...

# Manual test: create a repo with remote, fetch, then use twig add
git fetch origin
twig add feature/some-remote-branch
```

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Self-reviewed