### PR TITLE
docs(readme): add --sync example to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ twig init
 # Create a new worktree and branch
 twig add feat/new-feature
 
+# Copy uncommitted changes to a new worktree
+twig add feat/wip --sync
+
 # Move uncommitted changes to a new worktree
 twig add feat/wip --carry
 


### PR DESCRIPTION
## Overview

Add `--sync` usage example to README Quick Start section.

## Why

The `--sync` flag is a useful feature that copies uncommitted changes to a new worktree, but it wasn't shown in the Quick Start examples. Users may not discover this feature easily.

## What

- Add `--sync` example before the existing `--carry` example in Quick Start

## Type of Change

- [x] Documentation

## How to Test

- Review README.md Quick Start section
- Verify the example is clear and consistent with existing examples