### PR TITLE
docs(readme): add Claude Code plugin section

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ Run the following slash commands in a Claude Code session:
 
 ### What the Plugin Provides
 
-| Component | Description |
-| --------- | ----------- |
+| Component           | Description                                 |
+| ------------------- | ------------------------------------------- |
 | twig-operator agent | Executes twig commands based on user intent |
-| twig-guide skill | Provides command syntax and usage details |
+| twig-guide skill    | Provides command syntax and usage details   |
 
 ### Usage Examples
 


### PR DESCRIPTION
## Overview

Add documentation for the twig Claude Code plugin to the README.

## Why

The Claude Code plugin was added in #92 but there was no documentation in the main README explaining how to install and use it.

## What

- Add "Claude Code Plugin" section to README
- Document installation steps via marketplace commands
- Describe plugin components (twig-operator agent, twig-guide skill)
- Provide usage examples for AI-assisted worktree operations
- Format plugin table alignment for consistency

## Related

- #92

## Type of Change

- [x] Documentation

## How to Test

1. Review the README rendering on GitHub
2. Verify the plugin installation commands are accurate
3. Check that the usage examples align with the plugin's capabilities