### PR TITLE
docs(readme): clarify symlink purpose for gitignored files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Set `default_source` in config to always branch from a fixed base (e.g., main).
 ### Automatic symlink management via config
 
 Create new worktrees with personal settings like .envrc and Claude configs carried over.
-Start working immediately in new worktrees.
+Git worktree operations don't copy gitignored files, so twig uses symlinks to share these files across worktrees.
+Start working immediately in new worktrees without manual setup.
 
 ### Move uncommitted changes to a new branch
 


### PR DESCRIPTION
## Overview

Clarify why twig uses symlinks for sharing gitignored files across worktrees in the README.

## Why

The previous README description didn't explain the fundamental problem that symlinks solve: `git worktree add` cannot copy gitignored files (like `.envrc`, `.claude/`, etc.) to new worktrees. Users might not understand why twig uses symlinks without this context.

## What

Updated the "Automatic symlink management via config" section to:
- Explain that git worktree operations don't copy gitignored files
- Clarify that twig uses symlinks to solve this limitation
- Emphasize that this enables immediate work without manual setup

## Related

N/A

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

Read the updated README section (lines 43-47) and verify that:
- The explanation clearly states the problem (git worktree doesn't copy gitignored files)
- The solution (symlinks) is connected to the problem
- The benefit (immediate work without manual setup) is clear

## Checklist

- [x] Self-reviewed