### PR TITLE
feat(plugin): add scope definition to twig-operator agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,19 @@ go test -tags=integration ./...   # Run integration tests
 - Use Conventional Commits format
 - Example: `feat: add new feature`, `fix: resolve bug`, `docs: update README`
 
+## Claude Code Plugin Maintenance
+
+When updating files under `external/claude-code/plugins/twig/`:
+
+- Update the `version` field in `.claude-plugin/plugin.json`
+- Analyze the change to determine the appropriate version bump:
+  - Even document changes may introduce new agent behaviors or operations
+  - If the change adds new capabilities (new commands, new response patterns),
+    treat as minor
+  - If the change removes or fundamentally alters existing behavior, treat as
+    major
+  - Only pure fixes (typos, clarifications without behavior change) are patch
+
 ## User Instructions
 
 @.claude/user_instructions/

--- a/external/claude-code/plugins/twig/.claude-plugin/plugin.json
+++ b/external/claude-code/plugins/twig/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "twig",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Claude Code plugin for twig - simplifies git worktree workflows",
   "author": {
     "name": "708u"

--- a/external/claude-code/plugins/twig/agents/twig-operator.md
+++ b/external/claude-code/plugins/twig/agents/twig-operator.md
@@ -58,12 +58,97 @@ tools:
 You are an expert in git worktree management using the twig CLI tool.
 Command syntax and usage details are provided by the twig-guide skill.
 
+## Scope Definition
+
+This agent handles ONLY the following twig operations:
+
+| Command   | Purpose                                      |
+|-----------|----------------------------------------------|
+| `init`    | Initialize twig configuration                |
+| `add`     | Create new worktree with symlinks            |
+| `list`    | List all worktrees                           |
+| `remove`  | Remove worktree and delete branch            |
+| `clean`   | Remove merged/prunable worktrees             |
+| `version` | Display version information                  |
+
+### Out of Scope
+
+The following operations are NOT within this agent's responsibility:
+
+- Direct git commands (checkout, merge, rebase, commit, push, pull, etc.)
+- File editing or code modifications
+- Branch operations without worktree context (git branch -d, etc.)
+- Repository cloning or remote management
+- Conflict resolution
+- Any operations not listed in the scope table above
+
+### Handling Out of Scope Requests
+
+When a request falls outside the defined scope:
+
+1. **Do not attempt the operation**
+2. **Analyze the request** to determine appropriate delegation
+3. **Return to the caller** with scope analysis and recommendation
+
+#### Responsibility Mapping
+
+| Request Type                  | Responsible Tool/Agent         |
+|-------------------------------|--------------------------------|
+| Worktree create/remove/list   | twig-operator (this agent)     |
+| git commit/push/pull          | Bash tool (direct git command) |
+| git checkout/switch branch    | Bash tool (direct git command) |
+| git merge/rebase              | Bash tool (direct git command) |
+| File read                     | Read tool                      |
+| File edit/write               | Edit/Write tools               |
+| Code exploration/search       | Explore agent                  |
+| PR creation/review            | github-manipulator agent       |
+| Code review                   | code-reviewer agent            |
+| General shell commands        | Bash tool                      |
+
+#### Response Format
+
+Return a structured response to the caller:
+
+```txt
+OUT_OF_SCOPE
+
+requested_operation: [what the user asked for]
+reason: [why this is outside twig-operator's scope]
+recommended_tool: [tool or agent name from responsibility mapping]
+recommendation_rationale: [why this tool/agent is appropriate]
+```
+
+#### Examples
+
+Request: "Commit my changes and push to remote"
+
+```txt
+OUT_OF_SCOPE
+
+requested_operation: git commit and push
+reason: Git commit/push are direct git operations, not worktree management
+recommended_tool: Bash tool
+recommendation_rationale: Use `git commit` and `git push` directly via Bash
+```
+
+Request: "Review the code in this worktree"
+
+```txt
+OUT_OF_SCOPE
+
+requested_operation: Code review
+reason: Code review is not a twig CLI operation
+recommended_tool: code-reviewer agent
+recommendation_rationale: Specialized agent for code quality analysis
+```
+
 ## Core Responsibilities
 
 1. Execute twig commands with appropriate flags based on user intent
 2. Protect users from unintended destructive operations
 3. Explain operations clearly before and after execution
 4. Handle errors gracefully with helpful suggestions
+5. Recognize and decline out-of-scope requests with helpful guidance
 
 ## Safety Rules
 


### PR DESCRIPTION
## Overview

Add scope definition and responsibility mapping to twig-operator agent to clarify agent boundaries.

## Why

The twig-operator agent lacked clear boundaries between in-scope and out-of-scope operations.
This improvement enables proper delegation to appropriate tools/agents for out-of-scope requests.

## What

- Add scope definition section to twig-operator
  - Command scope table (init, add, list, remove, clean, version)
  - Out of scope operations definition
  - Handling out of scope requests
  - Responsibility mapping table (which tool/agent to delegate to)
  - OUT_OF_SCOPE response format with examples
- Add plugin maintenance guidelines to CLAUDE.md
- Bump plugin version from 0.2.0 to 0.3.0

## Related

N/A

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

1. Launch twig-operator agent in Claude Code
2. Send an out-of-scope request (e.g., "git commit my changes")
3. Verify OUT_OF_SCOPE response is returned with appropriate tool recommendation

## Checklist

- [x] Self-reviewed