### PR TITLE
feat: add fmt target for golangci-lint formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install lint sync-plugin-docs
+.PHONY: build install lint fmt sync-plugin-docs
 
 VERSION ?= dev
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -13,6 +13,9 @@ build:
 
 lint:
 	golangci-lint run ./...
+
+fmt:
+	golangci-lint fmt ./...
 
 sync-plugin-docs:
 	./scripts/sync-plugin-docs.sh


### PR DESCRIPTION
## Overview

Add a `fmt` target to the Makefile for code formatting using golangci-lint v2.x.

## Why

To provide a convenient way to format Go code using `golangci-lint fmt`, which is available in golangci-lint v2.x (added in #97 ).

## What

- Add `fmt` target to Makefile that runs `golangci-lint fmt ./...`
- Add `fmt` to `.PHONY` declaration

## Type of Change

- [x] Feature

## How to Test

```bash
make fmt
```

Verify that Go files are formatted according to golangci-lint rules.