### PR TITLE
perf: cache worktree list for multiple branch removal

### DIFF
--- a/cmd/twig/main.go
+++ b/cmd/twig/main.go
@@ -37,6 +37,7 @@ type ListCommander interface {
 // RemoveCommander defines the interface for remove operations.
 type RemoveCommander interface {
 	Run(branch string, cwd string, opts twig.RemoveOptions) (twig.RemovedWorktree, error)
+	RunMultiple(branches []string, cwd string, opts twig.RemoveOptions) twig.RemoveResult
 }
 
 // InitCommander defines the interface for init operations.
@@ -479,19 +480,11 @@ stop processing of remaining branches.`,
 			} else {
 				removeCmd = twig.NewDefaultRemoveCommand(cfg)
 			}
-			var result twig.RemoveResult
 
-			for _, branch := range args {
-				wt, err := removeCmd.Run(branch, cwd, twig.RemoveOptions{
-					Force:  twig.WorktreeForceLevel(forceCount),
-					DryRun: dryRun,
-				})
-				if err != nil {
-					wt.Branch = branch
-					wt.Err = err
-				}
-				result.Removed = append(result.Removed, wt)
-			}
+			result := removeCmd.RunMultiple(args, cwd, twig.RemoveOptions{
+				Force:  twig.WorktreeForceLevel(forceCount),
+				DryRun: dryRun,
+			})
 
 			formatted := result.Format(twig.FormatOptions{Verbose: verbose})
 			if formatted.Stderr != "" {

--- a/cmd/twig/main_test.go
+++ b/cmd/twig/main_test.go
@@ -423,6 +423,19 @@ func (m *mockRemoveCommander) Run(branch, cwd string, opts twig.RemoveOptions) (
 	return twig.RemovedWorktree{Branch: branch, WorktreePath: "/test/" + branch}, nil
 }
 
+func (m *mockRemoveCommander) RunMultiple(branches []string, cwd string, opts twig.RemoveOptions) twig.RemoveResult {
+	var result twig.RemoveResult
+	for _, branch := range branches {
+		wt, err := m.Run(branch, cwd, opts)
+		if err != nil {
+			wt.Branch = branch
+			wt.Err = err
+		}
+		result.Removed = append(result.Removed, wt)
+	}
+	return result
+}
+
 // mockInitCommander implements InitCommander for testing.
 type mockInitCommander struct {
 	result     twig.InitResult

--- a/git.go
+++ b/git.go
@@ -365,6 +365,13 @@ func (g *GitRunner) WorktreeFindByBranch(branch string) (*Worktree, error) {
 		return nil, err
 	}
 
+	return g.WorktreeFindByBranchFromList(branch, worktrees)
+}
+
+// WorktreeFindByBranchFromList returns the Worktree for the given branch from a pre-fetched list.
+// Returns an error if the branch is not checked out in any worktree.
+// This avoids repeated WorktreeList() calls when processing multiple branches.
+func (g *GitRunner) WorktreeFindByBranchFromList(branch string, worktrees []Worktree) (*Worktree, error) {
 	for i := range worktrees {
 		if worktrees[i].Branch == branch {
 			return &worktrees[i], nil


### PR DESCRIPTION
## Overview

Optimize `twig remove` command by caching the worktree list when removing multiple branches.

## Why

`WorktreeFindByBranch()` calls `WorktreeList()` on every invocation. When removing multiple branches in a single command, this results in redundant git operations.

## What

- Add `WorktreeFindByBranchFromList()` to `git.go` that accepts a pre-fetched worktree list
- Add `RunMultiple()` to `RemoveCommand` that fetches the worktree list once and reuses it
- Update CLI layer to use `RunMultiple()` instead of calling `Run()` in a loop
- Refactor existing `WorktreeFindByBranch()` to delegate to the new method

## Type of Change

- [x] Performance

## How to Test

```bash
# Remove multiple worktrees - should only call git worktree list once
twig remove feat/a feat/b feat/c
```

## Checklist

- [x] Tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./...`)