### PR TITLE
perf: batch fetch merged branches in clean command

### DIFF
--- a/git.go
+++ b/git.go
@@ -575,6 +575,22 @@ func (g *GitRunner) branchDelete(branch string, force bool) ([]byte, error) {
 	return g.Run(GitCmdBranch, flag, branch)
 }
 
+// MergedBranches returns all branches that are merged into target.
+// Uses a single git command to batch check merged status.
+func (g *GitRunner) MergedBranches(target string) ([]string, error) {
+	out, err := g.Run(GitCmdBranch, "--merged", target, "--format=%(refname:short)")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list merged branches: %w", err)
+	}
+	var branches []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			branches = append(branches, line)
+		}
+	}
+	return branches, nil
+}
+
 // IsBranchMerged checks if branch is merged into target.
 // First checks using git branch --merged (detects traditional merges).
 // If not found, falls back to checking if upstream is gone (squash/rebase merges).


### PR DESCRIPTION
## Overview

Optimize the `twig clean` command by batch fetching merged branches.

## Why

The current implementation calls `git branch --merged` for each worktree
individually, resulting in O(n) git invocations where n is the number of
worktrees. This can be slow when there are many worktrees to check.

## What

- Add `MergedBranches()` method to `GitRunner` for batch fetching all
  merged branches in a single git call
- Pass pre-computed `mergedSet` to `checkSkipReason()` and
  `checkPrunableSkipReason()` instead of `target` branch
- Update `getCleanReason()` to use the pre-computed set
- Update tests to use `mergedSet` parameter

## Related

Performance improvement for repositories with many worktrees.

## Type of Change

- [x] Performance

## How to Test

1. Create multiple worktrees in a repository
2. Merge some branches and leave others unmerged
3. Run `twig clean --check` and verify correct candidates are identified
4. Run `go test ./...` to verify all tests pass

## Checklist

- [x] Tests updated
- [x] Self-reviewed