### PR TITLE
feat: add check subcommand for configuration validation

### DIFF
--- a/check.go
+++ b/check.go
@@ -1,0 +1,289 @@
+package twig
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// CheckCommand validates twig configuration and symlink patterns.
+type CheckCommand struct {
+	FS     FileSystem
+	Git    *GitRunner
+	Config *Config
+}
+
+// CheckOptions holds options for the check command.
+type CheckOptions struct {
+	Verbose bool
+	Quiet   bool
+}
+
+// CheckSeverity represents the severity level of a check item.
+type CheckSeverity string
+
+const (
+	SeverityOK    CheckSeverity = "ok"
+	SeverityInfo  CheckSeverity = "info"
+	SeverityWarn  CheckSeverity = "warn"
+	SeverityError CheckSeverity = "error"
+)
+
+// CheckCategory represents the category of a check item.
+type CheckCategory string
+
+const (
+	CategoryConfig   CheckCategory = "config"
+	CategorySymlinks CheckCategory = "symlinks"
+)
+
+// CheckItem represents a single check result.
+type CheckItem struct {
+	Category   CheckCategory
+	Severity   CheckSeverity
+	Message    string
+	Suggestion string
+}
+
+// CheckResult holds the result of all checks.
+type CheckResult struct {
+	Items      []CheckItem
+	ConfigPath string
+}
+
+// NewCheckCommand creates a CheckCommand with explicit dependencies (for testing).
+func NewCheckCommand(fs FileSystem, git *GitRunner, cfg *Config) *CheckCommand {
+	return &CheckCommand{
+		FS:     fs,
+		Git:    git,
+		Config: cfg,
+	}
+}
+
+// NewDefaultCheckCommand creates a CheckCommand with production defaults.
+func NewDefaultCheckCommand(cfg *Config) *CheckCommand {
+	return NewCheckCommand(osFS{}, NewGitRunner(cfg.WorktreeSourceDir), cfg)
+}
+
+// CheckFormatOptions holds formatting options for CheckResult.
+type CheckFormatOptions struct {
+	Verbose bool
+	Quiet   bool
+}
+
+// ErrorCount returns the number of errors.
+func (r CheckResult) ErrorCount() int {
+	count := 0
+	for _, item := range r.Items {
+		if item.Severity == SeverityError {
+			count++
+		}
+	}
+	return count
+}
+
+// WarningCount returns the number of warnings.
+func (r CheckResult) WarningCount() int {
+	count := 0
+	for _, item := range r.Items {
+		if item.Severity == SeverityWarn {
+			count++
+		}
+	}
+	return count
+}
+
+// InfoCount returns the number of info items.
+func (r CheckResult) InfoCount() int {
+	count := 0
+	for _, item := range r.Items {
+		if item.Severity == SeverityInfo {
+			count++
+		}
+	}
+	return count
+}
+
+// Format formats the CheckResult for display.
+func (r CheckResult) Format(opts CheckFormatOptions) FormatResult {
+	var stdout strings.Builder
+
+	// Group items by category
+	configItems := r.filterByCategory(CategoryConfig)
+	symlinkItems := r.filterByCategory(CategorySymlinks)
+
+	if opts.Quiet {
+		// Quiet mode: only show errors
+		for _, item := range r.Items {
+			if item.Severity == SeverityError {
+				fmt.Fprintf(&stdout, "[error] %s\n", item.Message)
+			}
+		}
+		return FormatResult{Stdout: stdout.String()}
+	}
+
+	// Default or verbose mode
+	if len(configItems) > 0 {
+		r.formatCategory(&stdout, "config:", configItems, opts.Verbose)
+	}
+
+	if len(symlinkItems) > 0 {
+		if len(configItems) > 0 {
+			fmt.Fprintln(&stdout)
+		}
+		r.formatCategory(&stdout, "symlinks:", symlinkItems, opts.Verbose)
+	}
+
+	// Summary
+	fmt.Fprintf(&stdout, "\nSummary: %d errors, %d warnings, %d info\n",
+		r.ErrorCount(), r.WarningCount(), r.InfoCount())
+
+	return FormatResult{Stdout: stdout.String()}
+}
+
+func (r CheckResult) filterByCategory(cat CheckCategory) []CheckItem {
+	var items []CheckItem
+	for _, item := range r.Items {
+		if item.Category == cat {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+func (r CheckResult) formatCategory(w *strings.Builder, header string, items []CheckItem, verbose bool) {
+	fmt.Fprintln(w, header)
+
+	for _, item := range items {
+		// Skip ok items unless verbose
+		if item.Severity == SeverityOK && !verbose {
+			continue
+		}
+
+		fmt.Fprintf(w, "  [%s] %s\n", item.Severity, item.Message)
+		if item.Suggestion != "" {
+			fmt.Fprintf(w, "         suggestion: %s\n", item.Suggestion)
+		}
+	}
+}
+
+// Run executes all checks and returns the result.
+func (c *CheckCommand) Run() (CheckResult, error) {
+	var result CheckResult
+
+	// Set config path for reference
+	result.ConfigPath = filepath.Join(c.Config.WorktreeSourceDir, configDir, configFileName)
+
+	// Config checks
+	c.checkConfig(&result)
+
+	// Symlink pattern checks
+	c.checkSymlinks(&result)
+
+	return result, nil
+}
+
+func (c *CheckCommand) checkConfig(result *CheckResult) {
+	// Check TOML syntax validity (already validated by LoadConfig)
+	result.Items = append(result.Items, CheckItem{
+		Category: CategoryConfig,
+		Severity: SeverityOK,
+		Message:  "TOML syntax valid",
+	})
+
+	// Check worktree_destination_base_dir existence
+	destDir := c.Config.WorktreeDestBaseDir
+	if _, err := c.FS.Stat(destDir); err != nil {
+		if c.FS.IsNotExist(err) {
+			result.Items = append(result.Items, CheckItem{
+				Category:   CategoryConfig,
+				Severity:   SeverityWarn,
+				Message:    fmt.Sprintf("worktree_destination_base_dir does not exist: %s", destDir),
+				Suggestion: fmt.Sprintf("run 'mkdir -p %s'", destDir),
+			})
+		} else {
+			result.Items = append(result.Items, CheckItem{
+				Category: CategoryConfig,
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("cannot access worktree_destination_base_dir: %v", err),
+			})
+		}
+	} else {
+		// Check write permission by attempting to create a temp file
+		if writable := c.checkWritable(destDir); !writable {
+			result.Items = append(result.Items, CheckItem{
+				Category:   CategoryConfig,
+				Severity:   SeverityWarn,
+				Message:    fmt.Sprintf("worktree_destination_base_dir is not writable: %s", destDir),
+				Suggestion: "check directory permissions",
+			})
+		} else {
+			result.Items = append(result.Items, CheckItem{
+				Category: CategoryConfig,
+				Severity: SeverityOK,
+				Message:  "worktree_destination_base_dir exists and is writable",
+			})
+		}
+	}
+}
+
+func (c *CheckCommand) checkWritable(dir string) bool {
+	// Try to write a temp file to check writability
+	tmpFile := filepath.Join(dir, ".twig-check-write-test")
+	if err := c.FS.WriteFile(tmpFile, []byte{}, 0644); err != nil {
+		return false
+	}
+	c.FS.Remove(tmpFile)
+	return true
+}
+
+func (c *CheckCommand) checkSymlinks(result *CheckResult) {
+	srcDir := c.Config.WorktreeSourceDir
+
+	for _, pattern := range c.Config.Symlinks {
+		// Check for invalid glob pattern
+		matches, err := c.FS.Glob(srcDir, pattern)
+		if err != nil {
+			result.Items = append(result.Items, CheckItem{
+				Category: CategorySymlinks,
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("invalid glob pattern %q: %v", pattern, err),
+			})
+			continue
+		}
+
+		// Check if pattern matches any files
+		if len(matches) == 0 {
+			result.Items = append(result.Items, CheckItem{
+				Category:   CategorySymlinks,
+				Severity:   SeverityWarn,
+				Message:    fmt.Sprintf("pattern %q matches no files", pattern),
+				Suggestion: "remove from symlinks or create the file",
+			})
+			continue
+		}
+
+		// Check if matched files are gitignored
+		for _, match := range matches {
+			ignored, err := c.Git.CheckIgnore(match)
+			if err != nil {
+				// git check-ignore might fail, skip silently
+				continue
+			}
+			if ignored {
+				result.Items = append(result.Items, CheckItem{
+					Category: CategorySymlinks,
+					Severity: SeverityInfo,
+					Message:  fmt.Sprintf("%q is gitignored (symlink may not work as expected)", match),
+				})
+			}
+		}
+
+		// Add success item for verbose output
+		result.Items = append(result.Items, CheckItem{
+			Category: CategorySymlinks,
+			Severity: SeverityOK,
+			Message:  fmt.Sprintf("pattern %q matches %d file(s)", pattern, len(matches)),
+		})
+	}
+}

--- a/check_test.go
+++ b/check_test.go
@@ -1,0 +1,343 @@
+package twig
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/708u/twig/internal/testutil"
+)
+
+func TestCheckResult_Counts(t *testing.T) {
+	t.Parallel()
+
+	result := CheckResult{
+		Items: []CheckItem{
+			{Severity: SeverityError, Message: "error 1"},
+			{Severity: SeverityError, Message: "error 2"},
+			{Severity: SeverityWarn, Message: "warning 1"},
+			{Severity: SeverityInfo, Message: "info 1"},
+			{Severity: SeverityOK, Message: "ok 1"},
+		},
+	}
+
+	if got := result.ErrorCount(); got != 2 {
+		t.Errorf("ErrorCount() = %d, want 2", got)
+	}
+	if got := result.WarningCount(); got != 1 {
+		t.Errorf("WarningCount() = %d, want 1", got)
+	}
+	if got := result.InfoCount(); got != 1 {
+		t.Errorf("InfoCount() = %d, want 1", got)
+	}
+}
+
+func TestCheckResult_Format(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		result         CheckResult
+		opts           CheckFormatOptions
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name: "default_hides_ok_items",
+			result: CheckResult{
+				Items: []CheckItem{
+					{Category: CategoryConfig, Severity: SeverityOK, Message: "ok item"},
+					{Category: CategoryConfig, Severity: SeverityWarn, Message: "warning item"},
+				},
+			},
+			opts:           CheckFormatOptions{},
+			wantContains:   []string{"[warn] warning item", "0 errors, 1 warnings, 0 info"},
+			wantNotContain: []string{"[ok] ok item"},
+		},
+		{
+			name: "verbose_shows_ok_items",
+			result: CheckResult{
+				Items: []CheckItem{
+					{Category: CategoryConfig, Severity: SeverityOK, Message: "ok item"},
+					{Category: CategoryConfig, Severity: SeverityWarn, Message: "warning item"},
+				},
+			},
+			opts:         CheckFormatOptions{Verbose: true},
+			wantContains: []string{"[ok] ok item", "[warn] warning item"},
+		},
+		{
+			name: "quiet_only_shows_errors",
+			result: CheckResult{
+				Items: []CheckItem{
+					{Category: CategoryConfig, Severity: SeverityError, Message: "error item"},
+					{Category: CategoryConfig, Severity: SeverityWarn, Message: "warning item"},
+					{Category: CategoryConfig, Severity: SeverityInfo, Message: "info item"},
+				},
+			},
+			opts:           CheckFormatOptions{Quiet: true},
+			wantContains:   []string{"[error] error item"},
+			wantNotContain: []string{"[warn]", "[info]", "Summary"},
+		},
+		{
+			name: "shows_suggestions",
+			result: CheckResult{
+				Items: []CheckItem{
+					{
+						Category:   CategoryConfig,
+						Severity:   SeverityWarn,
+						Message:    "dir does not exist",
+						Suggestion: "run mkdir -p",
+					},
+				},
+			},
+			opts:         CheckFormatOptions{},
+			wantContains: []string{"suggestion: run mkdir -p"},
+		},
+		{
+			name: "groups_by_category",
+			result: CheckResult{
+				Items: []CheckItem{
+					{Category: CategoryConfig, Severity: SeverityWarn, Message: "config warning"},
+					{Category: CategorySymlinks, Severity: SeverityWarn, Message: "symlink warning"},
+				},
+			},
+			opts:         CheckFormatOptions{},
+			wantContains: []string{"config:", "symlinks:"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.result.Format(tt.opts)
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got.Stdout, want) {
+					t.Errorf("Stdout should contain %q, got:\n%s", want, got.Stdout)
+				}
+			}
+
+			for _, notWant := range tt.wantNotContain {
+				if strings.Contains(got.Stdout, notWant) {
+					t.Errorf("Stdout should not contain %q, got:\n%s", notWant, got.Stdout)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckCommand_Run(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		config      *Config
+		setupFS     func() *testutil.MockFS
+		setupGit    func() *testutil.MockGitExecutor
+		wantErrors  int
+		wantWarns   int
+		wantInfos   int
+		checkStdout func(t *testing.T, result CheckResult)
+	}{
+		{
+			name: "valid_config_and_symlinks",
+			config: &Config{
+				WorktreeSourceDir:   "/repo",
+				WorktreeDestBaseDir: "/worktrees",
+				Symlinks:            []string{".envrc"},
+			},
+			setupFS: func() *testutil.MockFS {
+				return &testutil.MockFS{
+					ExistingPaths: []string{"/worktrees"},
+					WritableDirs:  []string{"/worktrees"},
+					GlobResults: map[string][]string{
+						".envrc": {".envrc"},
+					},
+				}
+			},
+			setupGit: func() *testutil.MockGitExecutor {
+				return &testutil.MockGitExecutor{}
+			},
+			wantErrors: 0,
+			wantWarns:  0,
+			wantInfos:  0,
+		},
+		{
+			name: "worktree_dest_dir_not_exists",
+			config: &Config{
+				WorktreeSourceDir:   "/repo",
+				WorktreeDestBaseDir: "/missing-dir",
+				Symlinks:            []string{},
+			},
+			setupFS: func() *testutil.MockFS {
+				return &testutil.MockFS{
+					ExistingPaths: []string{}, // dir does not exist
+				}
+			},
+			setupGit: func() *testutil.MockGitExecutor {
+				return &testutil.MockGitExecutor{}
+			},
+			wantErrors: 0,
+			wantWarns:  1,
+			checkStdout: func(t *testing.T, result CheckResult) {
+				t.Helper()
+				found := false
+				for _, item := range result.Items {
+					if item.Severity == SeverityWarn &&
+						strings.Contains(item.Message, "does not exist") {
+						found = true
+						if item.Suggestion == "" {
+							t.Error("should have suggestion for missing dir")
+						}
+					}
+				}
+				if !found {
+					t.Error("should have warning about missing dir")
+				}
+			},
+		},
+		{
+			name: "symlink_pattern_no_match",
+			config: &Config{
+				WorktreeSourceDir:   "/repo",
+				WorktreeDestBaseDir: "/worktrees",
+				Symlinks:            []string{".envrc", "missing/**"},
+			},
+			setupFS: func() *testutil.MockFS {
+				return &testutil.MockFS{
+					ExistingPaths: []string{"/worktrees"},
+					WritableDirs:  []string{"/worktrees"},
+					GlobResults: map[string][]string{
+						".envrc":     {".envrc"},
+						"missing/**": {}, // no matches
+					},
+				}
+			},
+			setupGit: func() *testutil.MockGitExecutor {
+				return &testutil.MockGitExecutor{}
+			},
+			wantErrors: 0,
+			wantWarns:  1,
+			checkStdout: func(t *testing.T, result CheckResult) {
+				t.Helper()
+				found := false
+				for _, item := range result.Items {
+					if item.Severity == SeverityWarn &&
+						strings.Contains(item.Message, "missing/**") &&
+						strings.Contains(item.Message, "matches no files") {
+						found = true
+					}
+				}
+				if !found {
+					t.Error("should have warning about no matching files")
+				}
+			},
+		},
+		{
+			name: "gitignored_symlink_target",
+			config: &Config{
+				WorktreeSourceDir:   "/repo",
+				WorktreeDestBaseDir: "/worktrees",
+				Symlinks:            []string{".claude"},
+			},
+			setupFS: func() *testutil.MockFS {
+				return &testutil.MockFS{
+					ExistingPaths: []string{"/worktrees"},
+					WritableDirs:  []string{"/worktrees"},
+					GlobResults: map[string][]string{
+						".claude": {".claude"},
+					},
+				}
+			},
+			setupGit: func() *testutil.MockGitExecutor {
+				return &testutil.MockGitExecutor{
+					IgnoredPaths: []string{".claude"},
+				}
+			},
+			wantErrors: 0,
+			wantWarns:  0,
+			wantInfos:  1,
+			checkStdout: func(t *testing.T, result CheckResult) {
+				t.Helper()
+				found := false
+				for _, item := range result.Items {
+					if item.Severity == SeverityInfo &&
+						strings.Contains(item.Message, "gitignored") {
+						found = true
+					}
+				}
+				if !found {
+					t.Error("should have info about gitignored file")
+				}
+			},
+		},
+		{
+			name: "invalid_glob_pattern",
+			config: &Config{
+				WorktreeSourceDir:   "/repo",
+				WorktreeDestBaseDir: "/worktrees",
+				Symlinks:            []string{"[invalid"},
+			},
+			setupFS: func() *testutil.MockFS {
+				return &testutil.MockFS{
+					ExistingPaths: []string{"/worktrees"},
+					WritableDirs:  []string{"/worktrees"},
+					GlobErr:       &testutil.GlobPatternError{Pattern: "[invalid"},
+				}
+			},
+			setupGit: func() *testutil.MockGitExecutor {
+				return &testutil.MockGitExecutor{}
+			},
+			wantErrors: 1,
+			checkStdout: func(t *testing.T, result CheckResult) {
+				t.Helper()
+				found := false
+				for _, item := range result.Items {
+					if item.Severity == SeverityError &&
+						strings.Contains(item.Message, "invalid glob pattern") {
+						found = true
+					}
+				}
+				if !found {
+					t.Error("should have error about invalid glob pattern")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockFS := tt.setupFS()
+			mockGit := tt.setupGit()
+
+			cmd := &CheckCommand{
+				FS:     mockFS,
+				Git:    &GitRunner{Executor: mockGit, Dir: tt.config.WorktreeSourceDir},
+				Config: tt.config,
+			}
+
+			result, err := cmd.Run()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got := result.ErrorCount(); got != tt.wantErrors {
+				t.Errorf("ErrorCount() = %d, want %d", got, tt.wantErrors)
+			}
+			if got := result.WarningCount(); got != tt.wantWarns {
+				t.Errorf("WarningCount() = %d, want %d", got, tt.wantWarns)
+			}
+			if tt.wantInfos > 0 {
+				if got := result.InfoCount(); got != tt.wantInfos {
+					t.Errorf("InfoCount() = %d, want %d", got, tt.wantInfos)
+				}
+			}
+
+			if tt.checkStdout != nil {
+				tt.checkStdout(t, result)
+			}
+		})
+	}
+}

--- a/docs/reference/commands/check.md
+++ b/docs/reference/commands/check.md
@@ -1,0 +1,106 @@
+# check subcommand
+
+Validate twig configuration and symlink patterns.
+
+## Usage
+
+```txt
+twig check [flags]
+```
+
+## Flags
+
+| Flag        | Short | Description                     |
+|-------------|-------|---------------------------------|
+| `--verbose` | `-v`  | Show all checks including passed|
+| `--quiet`   | `-q`  | Show only errors                |
+
+## Behavior
+
+Performs validation checks on:
+
+1. Configuration files
+2. Symlink patterns
+
+### Config Checks
+
+| Check                                    | Severity | Description                     |
+|------------------------------------------|----------|---------------------------------|
+| TOML syntax                              | Error    | Validates TOML file parsing     |
+| `worktree_destination_base_dir` exists   | Warning  | Directory must exist            |
+| `worktree_destination_base_dir` writable | Warning  | Must be able to write files     |
+
+### Symlink Checks
+
+| Check                    | Severity | Description                            |
+|--------------------------|----------|----------------------------------------|
+| Invalid glob pattern     | Error    | Pattern syntax is invalid              |
+| Pattern matches no files | Warning  | No files found matching the pattern    |
+| Matched file is gitignored| Info    | File may not behave as expected        |
+
+## Output Format
+
+Default output groups items by category:
+
+```txt
+config:
+  [ok] TOML syntax valid
+  [warn] worktree_destination_base_dir does not exist: /path/to/worktrees
+         suggestion: run 'mkdir -p /path/to/worktrees'
+
+symlinks:
+  [warn] pattern ".envrc" matches no files
+         suggestion: remove from symlinks or create the file
+  [info] ".claude" is gitignored (symlink may not work as expected)
+
+Summary: 0 errors, 2 warnings, 1 info
+```
+
+With `--quiet`, only errors are shown:
+
+```txt
+[error] invalid TOML syntax: line 5: unexpected character
+```
+
+With `--verbose`, passed checks are also shown:
+
+```txt
+config:
+  [ok] TOML syntax valid
+  [ok] worktree_destination_base_dir exists and is writable
+
+symlinks:
+  [ok] pattern ".envrc" matches 1 file(s)
+  [ok] pattern "config/**" matches 3 file(s)
+
+Summary: 0 errors, 0 warnings, 0 info
+```
+
+## Exit Code
+
+- 0: No errors (warnings and info are allowed)
+- 1: One or more errors found
+
+## Examples
+
+```txt
+# Basic check
+twig check
+config:
+  [ok] TOML syntax valid
+  [ok] worktree_destination_base_dir exists and is writable
+
+symlinks:
+  [ok] pattern ".envrc" matches 1 file(s)
+
+Summary: 0 errors, 0 warnings, 0 info
+
+# Verbose output (shows all checks)
+twig check --verbose
+
+# Quiet output (errors only, for CI)
+twig check --quiet
+
+# Check in a different directory
+twig check -C /path/to/repo
+```

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/commands/check.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/commands/check.md
@@ -1,0 +1,106 @@
+# check subcommand
+
+Validate twig configuration and symlink patterns.
+
+## Usage
+
+```txt
+twig check [flags]
+```
+
+## Flags
+
+| Flag        | Short | Description                     |
+|-------------|-------|---------------------------------|
+| `--verbose` | `-v`  | Show all checks including passed|
+| `--quiet`   | `-q`  | Show only errors                |
+
+## Behavior
+
+Performs validation checks on:
+
+1. Configuration files
+2. Symlink patterns
+
+### Config Checks
+
+| Check                                    | Severity | Description                     |
+|------------------------------------------|----------|---------------------------------|
+| TOML syntax                              | Error    | Validates TOML file parsing     |
+| `worktree_destination_base_dir` exists   | Warning  | Directory must exist            |
+| `worktree_destination_base_dir` writable | Warning  | Must be able to write files     |
+
+### Symlink Checks
+
+| Check                    | Severity | Description                            |
+|--------------------------|----------|----------------------------------------|
+| Invalid glob pattern     | Error    | Pattern syntax is invalid              |
+| Pattern matches no files | Warning  | No files found matching the pattern    |
+| Matched file is gitignored| Info    | File may not behave as expected        |
+
+## Output Format
+
+Default output groups items by category:
+
+```txt
+config:
+  [ok] TOML syntax valid
+  [warn] worktree_destination_base_dir does not exist: /path/to/worktrees
+         suggestion: run 'mkdir -p /path/to/worktrees'
+
+symlinks:
+  [warn] pattern ".envrc" matches no files
+         suggestion: remove from symlinks or create the file
+  [info] ".claude" is gitignored (symlink may not work as expected)
+
+Summary: 0 errors, 2 warnings, 1 info
+```
+
+With `--quiet`, only errors are shown:
+
+```txt
+[error] invalid TOML syntax: line 5: unexpected character
+```
+
+With `--verbose`, passed checks are also shown:
+
+```txt
+config:
+  [ok] TOML syntax valid
+  [ok] worktree_destination_base_dir exists and is writable
+
+symlinks:
+  [ok] pattern ".envrc" matches 1 file(s)
+  [ok] pattern "config/**" matches 3 file(s)
+
+Summary: 0 errors, 0 warnings, 0 info
+```
+
+## Exit Code
+
+- 0: No errors (warnings and info are allowed)
+- 1: One or more errors found
+
+## Examples
+
+```txt
+# Basic check
+twig check
+config:
+  [ok] TOML syntax valid
+  [ok] worktree_destination_base_dir exists and is writable
+
+symlinks:
+  [ok] pattern ".envrc" matches 1 file(s)
+
+Summary: 0 errors, 0 warnings, 0 info
+
+# Verbose output (shows all checks)
+twig check --verbose
+
+# Quiet output (errors only, for CI)
+twig check --quiet
+
+# Check in a different directory
+twig check -C /path/to/repo
+```

--- a/git.go
+++ b/git.go
@@ -613,3 +613,21 @@ func (g *GitRunner) WorktreePrune() ([]byte, error) {
 	}
 	return out, nil
 }
+
+// CheckIgnore checks if a path is ignored by .gitignore.
+// Returns true if the path is ignored, false otherwise.
+func (g *GitRunner) CheckIgnore(path string) (bool, error) {
+	_, err := g.Run("check-ignore", "-q", path)
+	if err != nil {
+		// git check-ignore exits with 1 if not ignored, 128 on error
+		// -q (quiet) suppresses output
+		var exitErr interface{ ExitCode() int }
+		if errors.As(err, &exitErr) {
+			if exitErr.ExitCode() == 1 {
+				return false, nil
+			}
+		}
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
## Overview

Add a new `twig check` subcommand that validates twig configuration and symlink patterns.

## Why

Users need a way to verify their twig configuration is correct before running other commands. This helps catch common configuration errors like:
- Missing or non-writable worktree destination directories
- Symlink patterns that don't match any files
- Gitignored files in symlink patterns that may cause unexpected behavior

## What

- Add `CheckCommand` struct with validation logic for:
  - TOML syntax validity
  - `worktree_destination_base_dir` existence and writability
  - Symlink pattern matching
  - Gitignore detection for matched files
- Add `CheckIgnore()` method to `GitRunner` for `.gitignore` detection
- Add `check` subcommand to CLI with `--verbose` and `--quiet` flags
- Add unit tests with mock support
- Add documentation

## Related

Part of the configuration validation feature set.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

```bash
# Run check with default output
twig check

# Run check with verbose output (shows all checks)
twig check --verbose

# Run check with quiet output (errors only)
twig check --quiet

# Run tests
go test ./...
```

## Checklist

- [x] Tests added/updated
- [x] Self-reviewed