### PR TITLE
docs: add linter step to development workflow

### DIFF
--- a/.claude/rules/development/development-workflow.md
+++ b/.claude/rules/development/development-workflow.md
@@ -81,3 +81,17 @@ go test -tags=integration ./...
 
 This command runs both unit tests and integration tests.
 All tests must pass before the modification is considered complete.
+
+### 6. Run Linter
+
+Run golangci-lint to check code quality:
+
+```bash
+make lint
+make fmt
+```
+
+- `make lint`: Check for lint errors
+- `make fmt`: Auto-fix formatting issues
+
+All lint errors must be resolved before the modification is considered complete.


### PR DESCRIPTION
## Overview

Add linter step to development workflow documentation

## Why

Need to explicitly incorporate lint checks into the development flow to ensure code quality

## What

- Add "Run Linter" as step 6 in development-workflow.md
- Document usage of `make lint` and `make fmt` commands
- Specify that lint errors must be resolved before modification is considered complete

## Related

## Type of Change

- [x] Documentation

## How to Test

- Review the documentation content

## Checklist