### PR TITLE
chore(install): add ldflags to embed version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 
 install:
-	go install ./cmd/twig
+	go install -ldflags "$(LDFLAGS)" ./cmd/twig
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o out/twig ./cmd/twig


### PR DESCRIPTION
## Overview

Add ldflags to `make install` target to embed version information.

## Why

Previously, `make install` did not include ldflags, so `twig version` showed empty commit and date fields when installed via `make install`. Only `make build` properly embedded version info.

## What

- Add `-ldflags "$(LDFLAGS)"` to the install target in Makefile
- Now both `make install` and `make build` use the same LDFLAGS

## Related

<!-- Related issues or PRs (optional) -->

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

1. Run `make install`
2. Run `twig version`
3. Verify that commit and date are displayed (not empty)

```
$ twig version
version: dev
commit:  721eed1
date:    2026-01-17T22:41:37Z
```

## Checklist

- [x] Self-reviewed