### PR TITLE
feat(version): use semver format for dev builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build install lint fmt sync-plugin-docs
 
-VERSION ?= dev
+VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")-dev
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)

--- a/docs/reference/commands/version.md
+++ b/docs/reference/commands/version.md
@@ -14,24 +14,25 @@ twig --version
 - `twig version`: Displays version, commit hash, and build date
 - `twig --version`: Displays version only
 - Version is embedded at build time via ldflags
-- Local builds show "dev" as the version
+- Makefile builds show `<latest-tag>-dev` (e.g., `0.7.0-dev`)
+- Direct `go build` without ldflags shows `dev`
 
 ## Examples
 
 ```txt
 # Detailed output (subcommand)
 twig version
-version: v1.0.0
+version: 1.0.0
 commit:  abc1234
 date:    2025-01-06T12:00:00Z
 
 # Short output (flag)
 twig --version
-v1.0.0
+1.0.0
 
-# Local development build
+# Local development build (via Makefile)
 twig version
-version: dev
+version: 0.7.0-dev
 commit:  def5678
 date:    2025-01-06T10:30:00Z
 ```

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/commands/version.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/commands/version.md
@@ -14,24 +14,25 @@ twig --version
 - `twig version`: Displays version, commit hash, and build date
 - `twig --version`: Displays version only
 - Version is embedded at build time via ldflags
-- Local builds show "dev" as the version
+- Makefile builds show `<latest-tag>-dev` (e.g., `0.7.0-dev`)
+- Direct `go build` without ldflags shows `dev`
 
 ## Examples
 
 ```txt
 # Detailed output (subcommand)
 twig version
-version: v1.0.0
+version: 1.0.0
 commit:  abc1234
 date:    2025-01-06T12:00:00Z
 
 # Short output (flag)
 twig --version
-v1.0.0
+1.0.0
 
-# Local development build
+# Local development build (via Makefile)
 twig version
-version: dev
+version: 0.7.0-dev
 commit:  def5678
 date:    2025-01-06T10:30:00Z
 ```


### PR DESCRIPTION
## Overview

Use semver format for development builds instead of plain "dev".

## Why

Align dev version format with goreleaser's semver convention for consistency.

## What

- Makefile: Dynamically compute VERSION from latest git tag + `-dev` suffix
- Documentation: Updated to reflect the new version behavior

## Type of Change

- [x] Feature

## How to Test

```bash
make build
./out/twig version
# Expected: version: 0.7.0-dev (based on latest tag)

./out/twig --version
# Expected: 0.7.0-dev
```