### PR TITLE
refactor(logger): consolidate logger setup with createLogger helper

### DIFF
--- a/add.go
+++ b/add.go
@@ -3,6 +3,7 @@ package twig
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -13,6 +14,7 @@ type AddCommand struct {
 	FS             FileSystem
 	Git            *GitRunner
 	Config         *Config
+	Log            *slog.Logger
 	Sync           bool
 	CarryFrom      string
 	FilePatterns   []string
@@ -32,11 +34,15 @@ type AddOptions struct {
 }
 
 // NewAddCommand creates an AddCommand with explicit dependencies (for testing).
-func NewAddCommand(fs FileSystem, git *GitRunner, cfg *Config, opts AddOptions) *AddCommand {
+func NewAddCommand(fs FileSystem, git *GitRunner, cfg *Config, log *slog.Logger, opts AddOptions) *AddCommand {
+	if log == nil {
+		log = NewNopLogger()
+	}
 	return &AddCommand{
 		FS:             fs,
 		Git:            git,
 		Config:         cfg,
+		Log:            log,
 		Sync:           opts.Sync,
 		CarryFrom:      opts.CarryFrom,
 		FilePatterns:   opts.FilePatterns,
@@ -47,8 +53,8 @@ func NewAddCommand(fs FileSystem, git *GitRunner, cfg *Config, opts AddOptions) 
 }
 
 // NewDefaultAddCommand creates an AddCommand with production defaults.
-func NewDefaultAddCommand(cfg *Config, opts AddOptions) *AddCommand {
-	return NewAddCommand(osFS{}, NewGitRunner(cfg.WorktreeSourceDir), cfg, opts)
+func NewDefaultAddCommand(cfg *Config, log *slog.Logger, opts AddOptions) *AddCommand {
+	return NewAddCommand(osFS{}, NewGitRunner(cfg.WorktreeSourceDir), cfg, log, opts)
 }
 
 // SymlinkResult holds information about a symlink operation.

--- a/add_integration_test.go
+++ b/add_integration_test.go
@@ -1738,7 +1738,7 @@ init_submodules = true
 			t.Fatal(err)
 		}
 
-		cmd := NewDefaultAddCommand(result.Config, AddOptions{})
+		cmd := NewDefaultAddCommand(result.Config, NewNopLogger(), AddOptions{})
 
 		addResult, err := cmd.Run(t.Context(), "feature/with-submodule")
 		if err != nil {
@@ -1804,7 +1804,7 @@ init_submodules = true
 			t.Fatal(err)
 		}
 
-		cmd := NewDefaultAddCommand(result.Config, AddOptions{})
+		cmd := NewDefaultAddCommand(result.Config, NewNopLogger(), AddOptions{})
 
 		addResult, err := cmd.Run(t.Context(), "feature/no-submodule-init")
 		if err != nil {
@@ -1868,7 +1868,7 @@ init_submodules = false
 		}
 
 		// CLI flag forces init_submodules (regardless of config)
-		cmd := NewDefaultAddCommand(result.Config, AddOptions{
+		cmd := NewDefaultAddCommand(result.Config, NewNopLogger(), AddOptions{
 			InitSubmodules: true,
 		})
 

--- a/cmd/twig/main_integration_test.go
+++ b/cmd/twig/main_integration_test.go
@@ -36,7 +36,7 @@ func TestAddCommand_SourceFlag_Integration(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		addCmd := twig.NewDefaultAddCommand(result.Config, twig.AddOptions{})
+		addCmd := twig.NewDefaultAddCommand(result.Config, twig.NewNopLogger(), twig.AddOptions{})
 		_, err = addCmd.Run(t.Context(), "feat/a")
 		if err != nil {
 			t.Fatalf("failed to create feat/a worktree: %v", err)
@@ -59,7 +59,7 @@ func TestAddCommand_SourceFlag_Integration(t *testing.T) {
 		}
 
 		// Create feat/b from main's config
-		addCmd = twig.NewDefaultAddCommand(result.Config, twig.AddOptions{})
+		addCmd = twig.NewDefaultAddCommand(result.Config, twig.NewNopLogger(), twig.AddOptions{})
 		addResult, err := addCmd.Run(t.Context(), "feat/b")
 		if err != nil {
 			t.Fatalf("failed to create feat/b worktree: %v", err)
@@ -117,7 +117,7 @@ func TestAddCommand_SourceFlag_Integration(t *testing.T) {
 		}
 
 		// Create worktree using the resolved config
-		addCmd := twig.NewDefaultAddCommand(result.Config, twig.AddOptions{})
+		addCmd := twig.NewDefaultAddCommand(result.Config, twig.NewNopLogger(), twig.AddOptions{})
 		addResult, err := addCmd.Run(t.Context(), "feat/coexist")
 		if err != nil {
 			t.Fatalf("failed to create worktree: %v", err)
@@ -194,7 +194,7 @@ func TestAddCommand_DefaultSource_Integration(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		addCmd := twig.NewDefaultAddCommand(result.Config, twig.AddOptions{})
+		addCmd := twig.NewDefaultAddCommand(result.Config, twig.NewNopLogger(), twig.AddOptions{})
 		_, err = addCmd.Run(t.Context(), "feat/a")
 		if err != nil {
 			t.Fatalf("failed to create feat/a worktree: %v", err)
@@ -234,7 +234,7 @@ func TestAddCommand_DefaultSource_Integration(t *testing.T) {
 		}
 
 		// Create feat/b using main's config
-		addCmd = twig.NewDefaultAddCommand(resultMain.Config, twig.AddOptions{})
+		addCmd = twig.NewDefaultAddCommand(resultMain.Config, twig.NewNopLogger(), twig.AddOptions{})
 		_, err = addCmd.Run(t.Context(), "feat/b")
 		if err != nil {
 			t.Fatalf("failed to create feat/b worktree: %v", err)

--- a/init.go
+++ b/init.go
@@ -3,6 +3,7 @@ package twig
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 )
 
@@ -28,7 +29,8 @@ symlinks = []
 
 // InitCommand initializes twig configuration in a directory.
 type InitCommand struct {
-	FS FileSystem
+	FS  FileSystem
+	Log *slog.Logger
 }
 
 // InitOptions holds options for the init command.
@@ -51,15 +53,19 @@ type InitFormatOptions struct {
 }
 
 // NewInitCommand creates an InitCommand with explicit dependencies (for testing).
-func NewInitCommand(fs FileSystem) *InitCommand {
+func NewInitCommand(fs FileSystem, log *slog.Logger) *InitCommand {
+	if log == nil {
+		log = NewNopLogger()
+	}
 	return &InitCommand{
-		FS: fs,
+		FS:  fs,
+		Log: log,
 	}
 }
 
 // NewDefaultInitCommand creates an InitCommand with production defaults.
-func NewDefaultInitCommand() *InitCommand {
-	return NewInitCommand(osFS{})
+func NewDefaultInitCommand(log *slog.Logger) *InitCommand {
+	return NewInitCommand(osFS{}, log)
 }
 
 // Run executes the init command.

--- a/init_integration_test.go
+++ b/init_integration_test.go
@@ -17,7 +17,7 @@ func TestInitCommand_Integration(t *testing.T) {
 
 		tmpDir := t.TempDir()
 
-		cmd := NewDefaultInitCommand()
+		cmd := NewDefaultInitCommand(NewNopLogger())
 		result, err := cmd.Run(t.Context(), tmpDir, InitOptions{})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
@@ -45,7 +45,7 @@ func TestInitCommand_Integration(t *testing.T) {
 
 		tmpDir := t.TempDir()
 
-		cmd := NewDefaultInitCommand()
+		cmd := NewDefaultInitCommand(NewNopLogger())
 		_, err := cmd.Run(t.Context(), tmpDir, InitOptions{})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
@@ -89,7 +89,7 @@ func TestInitCommand_Integration(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cmd := NewDefaultInitCommand()
+		cmd := NewDefaultInitCommand(NewNopLogger())
 		result, err := cmd.Run(t.Context(), tmpDir, InitOptions{})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
@@ -125,7 +125,7 @@ func TestInitCommand_Integration(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cmd := NewDefaultInitCommand()
+		cmd := NewDefaultInitCommand(NewNopLogger())
 		result, err := cmd.Run(t.Context(), tmpDir, InitOptions{Force: true})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
@@ -153,7 +153,7 @@ func TestInitCommand_Integration(t *testing.T) {
 
 		tmpDir := t.TempDir()
 
-		cmd := NewDefaultInitCommand()
+		cmd := NewDefaultInitCommand(NewNopLogger())
 		result, err := cmd.Run(t.Context(), tmpDir, InitOptions{})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)
@@ -183,7 +183,7 @@ func TestInitCommand_Integration(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cmd := NewDefaultInitCommand()
+		cmd := NewDefaultInitCommand(NewNopLogger())
 		result, err := cmd.Run(t.Context(), tmpDir, InitOptions{})
 		if err != nil {
 			t.Fatalf("Run failed: %v", err)

--- a/init_test.go
+++ b/init_test.go
@@ -88,7 +88,7 @@ func TestInitCommand_Run(t *testing.T) {
 			t.Parallel()
 
 			mockFS := tt.setupFS()
-			cmd := NewInitCommand(mockFS)
+			cmd := NewInitCommand(mockFS, NewNopLogger())
 
 			result, err := cmd.Run(t.Context(), "/test", tt.opts)
 


### PR DESCRIPTION
## Overview

Consolidate logger setup across all commands using a shared helper function.

## Why

The codebase had duplicated logger initialization code in `list` and `remove` RunE functions, while `add`, `clean`, and `init` commands lacked logger support entirely. This created inconsistency and made it harder to maintain logging behavior.

## What

- Add `createLogger` helper function in `cmd/twig/main.go` that creates a logger based on verbosity level
- Add `Log` field to `AddCommand`, `CleanCommand`, and `InitCommand` structs
- Update all command constructors to accept a `*slog.Logger` parameter
- Replace duplicated logger setup code in `list` and `remove` RunE with `createLogger` calls
- Add logger support to `add`, `clean`, and `init` RunE functions
- Update test files for new constructor signatures

## Related

Follows the pattern established in #122 for slog-based logging.

## Type of Change

- [x] Refactoring

## How to Test

```bash
# Run all tests
go test -tags=integration ./...

# Verify debug logging works for all commands
twig list -vv
twig remove feat/test -vv --check
twig add feat/new -vv
twig clean -vv --check
twig init -vv
```

## Checklist

- [x] Tests added/updated
- [x] Self-reviewed