### PR TITLE
perf(remove): optimize with caching and parallel execution

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -296,13 +297,9 @@ func (c *CleanCommand) Run(ctx context.Context, cwd string, opts CleanOptions) (
 	wg.Wait()
 
 	// Sort candidates by original index to maintain consistent ordering
-	for i := range len(candidates) {
-		for j := i + 1; j < len(candidates); j++ {
-			if candidates[j].index < candidates[i].index {
-				candidates[i], candidates[j] = candidates[j], candidates[i]
-			}
-		}
-	}
+	slices.SortFunc(candidates, func(a, b indexedCandidate) int {
+		return a.index - b.index
+	})
 
 	// Extract candidates in order
 	for _, ic := range candidates {


### PR DESCRIPTION
## Overview

Optimize `twig remove` command performance by parallelizing `Run` operations using goroutines.

## Why

The `twig remove branch1 branch2 ...` command was executing sequentially, resulting in slower performance when removing multiple worktrees. This PR parallelizes the execution similar to the optimization pattern used in `twig clean` ( #133 ).

## What

- Parallelize `Run` operations in `cmd/twig/main.go` using goroutines
- Maintain result ordering by sorting with original indices
- Unify execution path for both mock and production (both use parallel execution)
- Make `mockRemoveCommander` thread-safe with `sync.Mutex`
- Replace manual bubble sort with `slices.SortFunc` in both `cmd/twig/main.go` and `clean.go`
- Update tests to verify called branches as a set (order-independent)

## Related

- Follow-up to #133 (clean command optimization)

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [x] Performance
- [ ] Other

## How to Test

```bash
# Create test worktrees
git branch test/parallel-1 main
git branch test/parallel-2 main
git branch test/parallel-3 main
twig add test/parallel-1 -q
twig add test/parallel-2 -q
twig add test/parallel-3 -q

# Remove with debug output to verify parallel execution
time twig remove test/parallel-1 test/parallel-2 test/parallel-3 -vv
```

## Checklist

- [x] Tests pass (`go test -tags=integration ./...`)
- [x] Lint passes (`make lint`)
- [x] Self-reviewed