### PR TITLE
fix: resolve relative worktree_destination_base_dir from config directory

### DIFF
--- a/config.go
+++ b/config.go
@@ -111,6 +111,9 @@ func LoadConfig(dir string) (*LoadConfigResult, error) {
 	if destBaseDir == "" {
 		repoName := filepath.Base(srcDir)
 		destBaseDir = filepath.Join(srcDir, "..", repoName+"-worktree")
+	} else if !filepath.IsAbs(destBaseDir) {
+		// Resolve relative paths based on the config file directory
+		destBaseDir = filepath.Join(srcDir, destBaseDir)
 	}
 	destBaseDir, err = filepath.Abs(destBaseDir)
 	if err != nil {


### PR DESCRIPTION
## Overview

Fix incorrect path resolution for relative `worktree_destination_base_dir` when using `default_source` configuration.

## Why

When `worktree_destination_base_dir` is set to a relative path (e.g., `"../my-workspace"`), it was being resolved based on the CLI's current working directory (`os.Getwd()`) instead of the config file's directory.

This caused incorrect worktree locations when:
1. Running `twig add` from a derived worktree
2. `default_source` is configured (which reloads config from the source worktree)

Example:
- Config file: `/path/to/repo/.twig/settings.local.toml`
- Setting: `worktree_destination_base_dir = "../my-workspace"`
- Expected: Resolve from `/path/to/repo/` → `/path/to/my-workspace/`
- Actual: Resolved from derived worktree cwd → `/path/to/my-workspace/feat/my-workspace/`

## What

- Modified `LoadConfig()` in `config.go` to resolve relative paths based on `srcDir` (the directory passed to `LoadConfig`)
- Added unit tests for relative and absolute path handling in `config_test.go`

## Related

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

1. Create a config with a relative `worktree_destination_base_dir`:
   ```toml
   # .twig/settings.local.toml
   worktree_destination_base_dir = "../my-workspace"
   default_source = "main"
   ```
2. Create a worktree: `twig add feat/test`
3. From the new worktree, create another: `twig add feat/test2`
4. Verify the worktree is created in the correct location (relative to the main repo, not the derived worktree)

Or run the unit tests:
```bash
go test -run TestLoadConfig_WorktreeDirs ./...
```

## Checklist

- [x] Tests added/updated
- [x] Self-reviewed