### PR TITLE
perf: use -unormal flag in git status for better performance

### DIFF
--- a/git.go
+++ b/git.go
@@ -483,7 +483,7 @@ type FileStatus struct {
 // unstaged, and untracked files. Status codes are the first 2 characters
 // from git status --porcelain output.
 func (g *GitRunner) ChangedFiles(ctx context.Context) ([]FileStatus, error) {
-	output, err := g.Run(ctx, GitCmdStatus, "--porcelain", "-uall")
+	output, err := g.Run(ctx, GitCmdStatus, "--porcelain", "-unormal")
 	if err != nil {
 		return nil, fmt.Errorf("failed to check git status: %w", err)
 	}


### PR DESCRIPTION
## Overview

Improve git status performance by using `-unormal` instead of `-uall` flag.

## Why

The `-uall` flag recursively lists all untracked files, which causes performance
degradation when large directories with many untracked files exist.
The `-unormal` flag reports untracked directories as single entries, resulting
in significantly faster execution.

## What

- Change `-uall` to `-unormal` in `ChangedFiles` function (`git.go:486`)

## Related

N/A

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [x] Performance
- [ ] Other

## How to Test

1. Run `go test -tags=integration ./...` to verify all tests pass
2. Benchmark comparison (n=30):

| Implementation | Mean | StdDev |
|----------------|------|--------|
| -uall (before) | 0.902s | 0.075s |
| -unormal (after) | 0.725s | 0.032s |

- Improvement: 19.6%
- t-statistic: 11.88 (p < 0.001, statistically highly significant)
- Effect size: Cohen's d = 3.07 (large effect)

## Checklist

- [x] Tests pass
- [x] Self-reviewed