### PR TITLE
docs: add release command documentation

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,76 @@
+# Release Command
+
+Create a new release for twig.
+
+## Prerequisites
+
+- Working directory must be clean (no uncommitted changes)
+- Must be on the main branch
+
+## Procedure
+
+### 1. Check current state
+
+```bash
+# Latest tag
+git tag --sort=-v:refname | head -1
+
+# Commits since last tag
+git log $(git tag --sort=-v:refname | head -1)..HEAD --oneline
+```
+
+### 2. Determine version bump
+
+Based on conventional commits since last tag:
+
+| Commit Type    | Version Bump | Changelog |
+|----------------|--------------|-----------|
+| `!` (breaking) | MAJOR        | Yes       |
+| `feat`         | MINOR        | Yes       |
+| `fix`          | PATCH        | Yes       |
+| `perf`         | PATCH        | Yes       |
+| `build`        | PATCH        | No        |
+| `chore`        | PATCH        | No        |
+| `refactor`     | PATCH        | No        |
+| `ci`           | -            | No        |
+| `docs`         | -            | No        |
+| `style`        | -            | No        |
+| `test`         | -            | No        |
+
+#### Judgment criteria
+
+- **Breaking change (`!`)**: CLI flags/arguments or config file format changes
+- **Claude plugin updates**: Use `chore` (not included in changelog)
+
+### 3. Create and push tag
+
+```bash
+git tag v<version>
+git push origin v<version>
+```
+
+### 4. Wait for goreleaser
+
+The goreleaser GitHub Action triggers automatically on tag push.
+
+```bash
+gh run list --limit 1
+gh run watch <run-id>
+```
+
+### 5. Verify release
+
+```bash
+gh release view v<version>
+```
+
+## Important
+
+- **DO NOT** use `gh release create` - goreleaser creates the release
+  automatically
+- Once a release is created for a tag, that tag becomes **immutable** and cannot
+  be reused even after deleting the release
+- If goreleaser fails before creating a release, you can re-trigger by deleting
+  and re-pushing the tag
+- If a release was already created (even partially), you must use a new version
+  number (e.g., v0.10.1 failed → use v0.10.2)


### PR DESCRIPTION
## Overview

Add a slash command documentation for the release process.

## Why

To standardize and document the release workflow for twig, ensuring consistent
version bumps based on conventional commits and proper use of goreleaser.

## What

- Add `.claude/commands/release.md` with:
  - Prerequisites for releasing
  - Version bump determination table based on commit types
  - Step-by-step release procedure
  - Important notes about goreleaser and tag immutability

## Related

N/A

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

1. Review the documentation in `.claude/commands/release.md`
2. Verify the version bump rules match conventional commit standards

## Checklist

- [x] Self-reviewed