### PR TITLE
fix: correct repository URL from twig-worktree to twig

### DIFF
--- a/.twig/settings.toml
+++ b/.twig/settings.toml
@@ -1,5 +1,5 @@
 # twig project configuration
-# See: https://github.com/708u/twig-worktree
+# See: https://github.com/708u/twig
 
 # Default source branch for new worktrees (prevents symlink chaining)
 default_source = "main"

--- a/init.go
+++ b/init.go
@@ -8,7 +8,7 @@ import (
 )
 
 const settingsTemplate = `# twig project configuration
-# See: https://github.com/708u/twig-worktree
+# See: https://github.com/708u/twig
 
 # Default source branch for new worktrees (prevents symlink chaining)
 default_source = "main"


### PR DESCRIPTION
## Overview

Fix incorrect repository URL references in configuration files.

## Why

The repository URL in `settingsTemplate` (init.go) and `.twig/settings.toml` incorrectly referenced `github.com/708u/twig-worktree` instead of the actual repository name `github.com/708u/twig`.

## What

- Updated `init.go`: Fixed URL in settingsTemplate comment
- Updated `.twig/settings.toml`: Fixed URL in configuration comment

## Related

N/A

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

1. Run `twig init` in a new directory
2. Verify the generated `.twig/settings.toml` contains the correct URL: `https://github.com/708u/twig`

## Checklist

- [x] Self-reviewed