### PR TITLE
chore: include all commit types in changelog

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -23,24 +23,23 @@ git log $(git tag --sort=-v:refname | head -1)..HEAD --oneline
 
 Based on conventional commits since last tag:
 
-| Commit Type    | Version Bump | Changelog |
-|----------------|--------------|-----------|
-| `!` (breaking) | MAJOR        | Yes       |
-| `feat`         | MINOR        | Yes       |
-| `fix`          | PATCH        | Yes       |
-| `perf`         | PATCH        | Yes       |
-| `build`        | PATCH        | No        |
-| `chore`        | PATCH        | No        |
-| `refactor`     | PATCH        | No        |
-| `ci`           | -            | No        |
-| `docs`         | -            | No        |
-| `style`        | -            | No        |
-| `test`         | -            | No        |
+| Commit Type    | Version Bump | Changelog Group  |
+|----------------|--------------|------------------|
+| `!` (breaking) | MAJOR        | Breaking Changes |
+| `feat`         | MINOR        | New Features     |
+| `fix`          | PATCH        | Bug Fixes        |
+| `perf`         | PATCH        | Performance      |
+| `docs`         | -            | Documentation    |
+| `build`        | PATCH        | Other Changes    |
+| `chore`        | PATCH        | Other Changes    |
+| `refactor`     | PATCH        | Other Changes    |
+| `ci`           | -            | Other Changes    |
+| `style`        | -            | Other Changes    |
+| `test`         | -            | Other Changes    |
 
 #### Judgment criteria
 
 - **Breaking change (`!`)**: CLI flags/arguments or config file format changes
-- **Claude plugin updates**: Use `chore` (not included in changelog)
 
 ### 3. Create and push tag
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -81,16 +81,13 @@ changelog:
     - title: "Performance"
       regexp: '^perf(\(.+\))?:.+$'
       order: 3
+    - title: "Documentation"
+      regexp: '^docs(\(.+\))?:.+$'
+      order: 4
     - title: "Other Changes"
       order: 999
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
-      - "^chore:"
-      - "^ci:"
-      - "^style:"
-      - "^refactor:"
       - "^Merge pull request"
       - "^Merge branch"
 


### PR DESCRIPTION
## Overview

Configure goreleaser to include all commit types in the release changelog.

## Why

Previously, only `feat`, `fix`, `perf`, and breaking changes were included in the changelog. Other commit types like `docs`, `chore`, `refactor`, `test`, `ci`, and `style` were excluded, making the changelog incomplete.

## What

- Add Documentation group for `docs` commits in goreleaser changelog
- Simplify exclude filters to only exclude Merge commits
- Update release.md table to reflect the new changelog grouping

### Changelog Groups

| Group | Commits |
|-------|---------|
| Breaking Changes | `!` |
| New Features | `feat` |
| Bug Fixes | `fix` |
| Performance | `perf` |
| Documentation | `docs` |
| Other Changes | `chore`, `test`, `ci`, `style`, `refactor`, `build`, etc. |

## Related

N/A

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [x] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

1. Review `.goreleaser.yaml` changes
2. Review `.claude/commands/release.md` table updates
3. Verify changelog grouping logic is correct

## Checklist

- [x] Self-reviewed