### PR TITLE
docs: fix markdown table formatting in release command

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -25,7 +25,7 @@ Based on conventional commits since last tag:
 
 | Commit Type    | Version Bump | Changelog Group  |
 |----------------|--------------|------------------|
-| `!` (breaking) | MAJOR        | Breaking Changes |
+|  ! (breaking)  | MAJOR        | Breaking Changes |
 | `feat`         | MINOR        | New Features     |
 | `fix`          | PATCH        | Bug Fixes        |
 | `perf`         | PATCH        | Performance      |
@@ -39,7 +39,7 @@ Based on conventional commits since last tag:
 
 #### Judgment criteria
 
-- **Breaking change (`!`)**: CLI flags/arguments or config file format changes
+- **Breaking change ('!')**: CLI flags/arguments or config file format changes
 
 ### 3. Create and push tag
 


### PR DESCRIPTION
## Overview

Fix markdown formatting issues in `.claude/commands/release.md`.

## Why

The backticks around `!` (breaking change indicator) in the markdown table
cause rendering issues with special characters inside code spans.

## What

- Remove backticks from breaking change indicator in table cells
- Change `` `!` `` to ` ! ` (with spaces for alignment)
- Change `` `!` `` to `'!'` in judgment criteria section

## Related

None

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

1. View the rendered markdown in `.claude/commands/release.md`
2. Verify the table displays correctly without formatting issues

## Checklist

- [x] Self-reviewed