### PR TITLE
refactor(hooks): improve pre-commit check warning message

### DIFF
--- a/.claude/hooks/pre-commit-check/pre-commit-check.py
+++ b/.claude/hooks/pre-commit-check/pre-commit-check.py
@@ -141,12 +141,15 @@ def main():
     state["warned"] = True
     save_state(session_id, state)
 
-    print("Warning: Have you run the necessary checks?", file=sys.stderr)
+    print("BLOCKED: Required checks not confirmed.", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Run before committing:", file=sys.stderr)
     for category, info in CHECKS.items():
         print(f"  [{category}] {info['when']}", file=sys.stderr)
         for cmd in info["commands"]:
             print(f"    - {cmd}", file=sys.stderr)
-    print("Commit again to proceed.", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("After running checks, commit again to confirm.", file=sys.stderr)
     sys.exit(2)
 
 


### PR DESCRIPTION
## Overview

Improve pre-commit check hook warning message for better visibility and clarity.

## Why

The previous warning message had issues:
- "Warning" felt too mild and was easily ignored
- "Commit again to proceed" implied no verification was needed
- The message lacked visual structure

## What

- Change "Warning" to "BLOCKED" for stronger emphasis
- Replace question form with assertive statement
- Add "After running checks" to clarify required action sequence
- Add blank lines for better readability

## Related

N/A

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

1. Stage some changes and attempt to commit
2. Verify the new warning message format:
   - Shows "BLOCKED: Required checks not confirmed."
   - Lists checks with proper formatting
   - Ends with "After running checks, commit again to confirm."
3. Commit again to verify it proceeds

## Checklist

- [x] Self-reviewed