### PR TITLE
feat(sync): show source branch in default output

### DIFF
--- a/docs/reference/commands/sync.md
+++ b/docs/reference/commands/sync.md
@@ -83,7 +83,7 @@ This is useful for previewing the sync operation.
 ### Default Output
 
 ```txt
-Synced feat/a: 2 symlinks created, 1 submodule(s) initialized
+Synced feat/a from main: 2 symlinks created, 1 submodule(s) initialized
 Skipped feat/b: up to date
 ```
 
@@ -94,7 +94,7 @@ Syncing from main to feat/a
 Created symlink: /repo/feat/a/.envrc -> /repo/main/.envrc
 Created symlink: /repo/feat/a/.tool-versions -> /repo/main/.tool-versions
 Initialized 1 submodule(s)
-Synced feat/a: 2 symlinks created, 1 submodule(s) initialized
+Synced feat/a from main: 2 symlinks created, 1 submodule(s) initialized
 ```
 
 ### Check Mode Output

--- a/external/claude-code/plugins/twig/.claude-plugin/plugin.json
+++ b/external/claude-code/plugins/twig/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "twig",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Claude Code plugin for twig - simplifies git worktree workflows",
   "author": {
     "name": "708u"

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/commands/sync.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/commands/sync.md
@@ -83,7 +83,7 @@ This is useful for previewing the sync operation.
 ### Default Output
 
 ```txt
-Synced feat/a: 2 symlinks created, 1 submodule(s) initialized
+Synced feat/a from main: 2 symlinks created, 1 submodule(s) initialized
 Skipped feat/b: up to date
 ```
 
@@ -94,7 +94,7 @@ Syncing from main to feat/a
 Created symlink: /repo/feat/a/.envrc -> /repo/main/.envrc
 Created symlink: /repo/feat/a/.tool-versions -> /repo/main/.tool-versions
 Initialized 1 submodule(s)
-Synced feat/a: 2 symlinks created, 1 submodule(s) initialized
+Synced feat/a from main: 2 symlinks created, 1 submodule(s) initialized
 ```
 
 ### Check Mode Output

--- a/sync.go
+++ b/sync.go
@@ -182,7 +182,7 @@ func (r SyncResult) formatTarget(stdout, stderr *strings.Builder, t SyncTargetRe
 	if t.SubmoduleInit.Attempted && t.SubmoduleInit.Count > 0 {
 		submoduleInfo = fmt.Sprintf(", %d submodule(s) initialized", t.SubmoduleInit.Count)
 	}
-	fmt.Fprintf(stdout, "Synced %s: %d symlinks created%s\n", t.Branch, createdCount, submoduleInfo)
+	fmt.Fprintf(stdout, "Synced %s from %s: %d symlinks created%s\n", t.Branch, r.SourceBranch, createdCount, submoduleInfo)
 }
 
 // Run syncs symlinks and submodules from source to target worktrees.

--- a/sync_test.go
+++ b/sync_test.go
@@ -90,7 +90,7 @@ feat/a:
 				},
 			},
 			opts:       SyncFormatOptions{},
-			wantStdout: "Synced feat/a: 2 symlinks created, 1 submodule(s) initialized\n",
+			wantStdout: "Synced feat/a from main: 2 symlinks created, 1 submodule(s) initialized\n",
 		},
 		{
 			name: "normal_mode_verbose",
@@ -112,7 +112,7 @@ feat/a:
 			wantStdout: `Syncing from main to feat/a
 Created symlink: /repo/feat/a/.envrc -> /repo/main/.envrc
 Initialized 2 submodule(s)
-Synced feat/a: 1 symlinks created, 2 submodule(s) initialized
+Synced feat/a from main: 1 symlinks created, 2 submodule(s) initialized
 `,
 		},
 		{


### PR DESCRIPTION
## Overview

Add source branch display to the sync command's default output format.

## Why

When running `twig sync`, users need to know which branch the symlinks and
submodules are being synced from. Previously, only the target branch was shown,
requiring users to check verbose output or remember the source.

## What

- Modified `formatTarget` in sync.go to include source branch in output
- Updated tests to reflect new output format
- Updated documentation examples

**Before:**
```
Synced feat/a: 2 symlinks created, 1 submodule(s) initialized
```

**After:**
```
Synced feat/a from main: 2 symlinks created, 1 submodule(s) initialized
```

## Type of Change

- [x] Feature

## How to Test

```bash
# Create a worktree and sync it
twig add feat/test
twig sync feat/test --source main
# Output should show "Synced feat/test from main: ..."
```

## Checklist

- [x] Tests added/updated
- [x] Self-reviewed
- [x] Documentation updated