### PR TITLE
refactor(clean): introduce lineWriter for consistent indentation

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -76,6 +76,18 @@ func (r CleanResult) CleanableCount() int {
 	return count
 }
 
+// lineWriter provides indented line writing for formatted output.
+type lineWriter struct {
+	w *strings.Builder
+}
+
+// Line writes a formatted line with the specified indentation level.
+// Each level adds 2 spaces of indentation.
+func (lw *lineWriter) Line(level int, format string, args ...any) {
+	fmt.Fprintf(lw.w, "%s"+format+"\n",
+		append([]any{strings.Repeat("  ", level)}, args...)...)
+}
+
 // Format formats the CleanResult for display.
 func (r CleanResult) Format(opts FormatOptions) FormatResult {
 	var stdout, stderr strings.Builder
@@ -105,19 +117,20 @@ func (r CleanResult) Format(opts FormatOptions) FormatResult {
 	}
 
 	// No cleanable candidates
+	lw := &lineWriter{w: &stdout}
 	if len(cleanable) == 0 {
 		if opts.Verbose && len(skipped) > 0 {
-			fmt.Fprintln(&stdout, "skip:")
+			lw.Line(0, "skip:")
 			for _, c := range skipped {
-				fmt.Fprintf(&stdout, "  %s\n", c.Branch)
+				lw.Line(1, "%s", c.Branch)
 				if c.CleanReason != "" {
-					fmt.Fprintf(&stdout, "    ✓ %s\n", c.CleanReason)
+					lw.Line(2, "✓ %s", c.CleanReason)
 				}
-				fmt.Fprintf(&stdout, "    ✗ %s\n", c.SkipReason.Format(r.TargetBranch))
+				lw.Line(2, "✗ %s", c.SkipReason.Format(r.TargetBranch))
 				if (c.SkipReason == SkipHasChanges || c.SkipReason == SkipDirtySubmodule) &&
 					len(c.ChangedFiles) > 0 {
 					for _, f := range c.ChangedFiles {
-						fmt.Fprintf(&stdout, "      %s %s\n", f.Status, f.Path)
+						lw.Line(3, "%s %s", f.Status, f.Path)
 					}
 				}
 			}
@@ -128,29 +141,29 @@ func (r CleanResult) Format(opts FormatOptions) FormatResult {
 	}
 
 	// Output cleanable candidates with group header and reasons
-	fmt.Fprintln(&stdout, "clean:")
+	lw.Line(0, "clean:")
 	for _, c := range cleanable {
 		reason := string(c.CleanReason)
 		if c.Prunable {
 			reason = "prunable, " + reason
 		}
-		fmt.Fprintf(&stdout, "  %s (%s)\n", c.Branch, reason)
+		lw.Line(1, "%s (%s)", c.Branch, reason)
 	}
 
 	// Output skipped candidates with group header (verbose only)
 	if opts.Verbose && len(skipped) > 0 {
 		fmt.Fprintln(&stdout)
-		fmt.Fprintln(&stdout, "skip:")
+		lw.Line(0, "skip:")
 		for _, c := range skipped {
-			fmt.Fprintf(&stdout, "  %s\n", c.Branch)
+			lw.Line(1, "%s", c.Branch)
 			if c.CleanReason != "" {
-				fmt.Fprintf(&stdout, "    ✓ %s\n", c.CleanReason)
+				lw.Line(2, "✓ %s", c.CleanReason)
 			}
-			fmt.Fprintf(&stdout, "    ✗ %s\n", c.SkipReason.Format(r.TargetBranch))
+			lw.Line(2, "✗ %s", c.SkipReason.Format(r.TargetBranch))
 			if (c.SkipReason == SkipHasChanges || c.SkipReason == SkipDirtySubmodule) &&
 				len(c.ChangedFiles) > 0 {
 				for _, f := range c.ChangedFiles {
-					fmt.Fprintf(&stdout, "      %s %s\n", f.Status, f.Path)
+					lw.Line(3, "%s %s", f.Status, f.Path)
 				}
 			}
 		}


### PR DESCRIPTION
## Overview

Improve indent management in clean.go by introducing lineWriter struct.

## Why

Hardcoded indent strings (e.g., `"  "`, `"    "`) are scattered throughout
Format() method, making the code harder to maintain and prone to
inconsistencies.

## What

- Add `lineWriter` struct with `Line()` method for level-based indentation
- Replace all hardcoded indent strings in Format() method with lineWriter
- Each indentation level adds 2 spaces

## Related

N/A

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

```bash
go test ./...
make lint
```

## Checklist

- [x] Tests pass
- [x] Self-reviewed