### PR TITLE
perf(clean): reduce redundant Check calls by caching results

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -54,6 +54,7 @@ type CleanCandidate struct {
 	SkipReason   SkipReason
 	CleanReason  CleanReason
 	ChangedFiles []FileStatus
+	checkResult  *CheckResult // cached Check result for Run reuse (internal)
 }
 
 // CleanResult aggregates results from clean operations.
@@ -339,6 +340,7 @@ func (c *CleanCommand) Run(ctx context.Context, cwd string, opts CleanOptions) (
 				SkipReason:   checkResult.SkipReason,
 				CleanReason:  checkResult.CleanReason,
 				ChangedFiles: checkResult.ChangedFiles,
+				checkResult:  &checkResult,
 			}
 
 			c.Log.DebugContext(ctx, "check completed",
@@ -403,8 +405,9 @@ func (c *CleanCommand) Run(ctx context.Context, cwd string, opts CleanOptions) (
 				"branch", candidate.Branch)
 
 			wt, err := removeCmd.Run(ctx, candidate.Branch, cwd, RemoveOptions{
-				Force: opts.Force,
-				Check: false,
+				Force:      opts.Force,
+				Check:      false,
+				PreChecked: candidate.checkResult,
 			})
 			if err != nil {
 				c.Log.DebugContext(ctx, "removal failed",

--- a/git.go
+++ b/git.go
@@ -735,8 +735,10 @@ const (
 type SubmoduleCleanStatus int
 
 const (
+	// SubmoduleCleanStatusUnknown: status not yet checked (zero value).
+	SubmoduleCleanStatusUnknown SubmoduleCleanStatus = iota
 	// SubmoduleCleanStatusNone: no initialized submodules exist.
-	SubmoduleCleanStatusNone SubmoduleCleanStatus = iota
+	SubmoduleCleanStatusNone
 	// SubmoduleCleanStatusClean: submodules exist but all are clean.
 	SubmoduleCleanStatusClean
 	// SubmoduleCleanStatusDirty: submodules have uncommitted changes or are at different commits.


### PR DESCRIPTION
## Overview

Improve `twig clean` performance by eliminating redundant git command calls.

## Why

When `CleanCommand.Run()` calls `RemoveCommand.Run()` for each cleanable worktree, the `Run()` method internally calls `Check()` again even though `CleanCommand` has already performed the check. This results in duplicate:

- `git worktree list` calls (via `WorktreeFindByBranch`)
- `git status` calls (via `ChangedFiles`)
- `git submodule status` calls (via `CheckSubmoduleCleanStatus`)

For repositories with many worktrees, this causes noticeable performance degradation.

## What

- Add `SubmoduleStatus` field to `CheckResult` for caching submodule clean status
- Add `PreChecked` field to `RemoveOptions` to pass pre-fetched Check results
- Pass cached `CheckResult` from `CleanCommand` to `RemoveCommand.Run()`
- Add `SubmoduleCleanStatusUnknown` as zero value for unchecked state
- Modify `RemoveCommand.Run()` to skip `Check()` when `PreChecked` is provided

## Related

None

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [x] Performance
- [ ] Other

## How to Test

```bash
# Run tests
go test -tags=integration ./...

# Manual verification with large repo
time twig clean --check
```

## Checklist

- [x] Tests pass
- [x] Self-reviewed