### PR TITLE
feat(list): add verbose output with changed files and lock reasons

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -76,18 +76,6 @@ func (r CleanResult) CleanableCount() int {
 	return count
 }
 
-// lineWriter provides indented line writing for formatted output.
-type lineWriter struct {
-	w *strings.Builder
-}
-
-// Line writes a formatted line with the specified indentation level.
-// Each level adds 2 spaces of indentation.
-func (lw *lineWriter) Line(level int, format string, args ...any) {
-	fmt.Fprintf(lw.w, "%s"+format+"\n",
-		append([]any{strings.Repeat("  ", level)}, args...)...)
-}
-
 // Format formats the CleanResult for display.
 func (r CleanResult) Format(opts FormatOptions) FormatResult {
 	var stdout, stderr strings.Builder

--- a/docs/reference/commands/list.md
+++ b/docs/reference/commands/list.md
@@ -21,29 +21,55 @@ twig list [flags]
 - Default output shows path, commit hash, and branch name
   (compatible with `git worktree list`)
 - With `--quiet`: shows only worktree paths
+- With `--verbose`: shows uncommitted changes and lock reasons
 - With `-vv`: shows git command execution traces (for debugging)
+- When `--quiet` is specified, `--verbose` is ignored
+
+### Verbose Output
+
+With `--verbose`, each worktree line is followed by additional
+detail lines:
+
+- **Lock reason**: displayed when a worktree is locked with a
+  reason
+- **Changed files**: uncommitted changes in the worktree,
+  using `git status --porcelain` format
+
+Changed files are fetched in parallel for all worktrees.
+Bare and prunable worktrees are skipped (no working tree).
 
 ## Examples
 
 ```txt
 # Default output (git worktree list compatible)
 twig list
-/Users/user/repo                                   abc1234 [main]
-/Users/user/repo-worktree/feat/add-list-command    def5678 [feat/add-list-command]
-/Users/user/repo-worktree/feat/add-move-command    012abcd [feat/add-move-command]
+/Users/user/repo                abc1234 [main]
+/Users/user/repo-worktree/a     def5678 [feat/a]
+/Users/user/repo-worktree/b     012abcd [feat/b]
+
+# Verbose output (shows changes and lock reasons)
+twig list -v
+/Users/user/repo                abc1234 [main]
+/Users/user/repo-worktree/a     def5678 [feat/a]
+   M src/main.go
+  ?? tmp/debug.log
+/Users/user/repo-worktree/usb   789abcd [feat/usb] locked
+  lock reason: USB drive work
+   M config.toml
+/Users/user/repo-worktree/b     012abcd [feat/b]
 
 # Quiet output (paths only, for scripting)
 twig list -q
 /Users/user/repo
-/Users/user/repo-worktree/feat/add-list-command
-/Users/user/repo-worktree/feat/add-move-command
+/Users/user/repo-worktree/a
+/Users/user/repo-worktree/b
 
 # Debug output (shows git command traces)
 twig list -vv
-2026-01-17 12:34:56.000 [DEBUG] git: git -C /Users/user/repo worktree list --porcelain
-/Users/user/repo                                   abc1234 [main]
-/Users/user/repo-worktree/feat/add-list-command    def5678 [feat/add-list-command]
-/Users/user/repo-worktree/feat/add-move-command    012abcd [feat/add-move-command]
+2026-01-17 12:34:56.000 [DEBUG] git: git -C ... worktree list --porcelain
+/Users/user/repo                abc1234 [main]
+/Users/user/repo-worktree/a     def5678 [feat/a]
+/Users/user/repo-worktree/b     012abcd [feat/b]
 ```
 
 ## Shell Integration

--- a/external/claude-code/plugins/twig/.claude-plugin/plugin.json
+++ b/external/claude-code/plugins/twig/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "twig",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Claude Code plugin for twig - simplifies git worktree workflows",
   "author": {
     "name": "708u"

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/commands/list.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/commands/list.md
@@ -21,29 +21,55 @@ twig list [flags]
 - Default output shows path, commit hash, and branch name
   (compatible with `git worktree list`)
 - With `--quiet`: shows only worktree paths
+- With `--verbose`: shows uncommitted changes and lock reasons
 - With `-vv`: shows git command execution traces (for debugging)
+- When `--quiet` is specified, `--verbose` is ignored
+
+### Verbose Output
+
+With `--verbose`, each worktree line is followed by additional
+detail lines:
+
+- **Lock reason**: displayed when a worktree is locked with a
+  reason
+- **Changed files**: uncommitted changes in the worktree,
+  using `git status --porcelain` format
+
+Changed files are fetched in parallel for all worktrees.
+Bare and prunable worktrees are skipped (no working tree).
 
 ## Examples
 
 ```txt
 # Default output (git worktree list compatible)
 twig list
-/Users/user/repo                                   abc1234 [main]
-/Users/user/repo-worktree/feat/add-list-command    def5678 [feat/add-list-command]
-/Users/user/repo-worktree/feat/add-move-command    012abcd [feat/add-move-command]
+/Users/user/repo                abc1234 [main]
+/Users/user/repo-worktree/a     def5678 [feat/a]
+/Users/user/repo-worktree/b     012abcd [feat/b]
+
+# Verbose output (shows changes and lock reasons)
+twig list -v
+/Users/user/repo                abc1234 [main]
+/Users/user/repo-worktree/a     def5678 [feat/a]
+   M src/main.go
+  ?? tmp/debug.log
+/Users/user/repo-worktree/usb   789abcd [feat/usb] locked
+  lock reason: USB drive work
+   M config.toml
+/Users/user/repo-worktree/b     012abcd [feat/b]
 
 # Quiet output (paths only, for scripting)
 twig list -q
 /Users/user/repo
-/Users/user/repo-worktree/feat/add-list-command
-/Users/user/repo-worktree/feat/add-move-command
+/Users/user/repo-worktree/a
+/Users/user/repo-worktree/b
 
 # Debug output (shows git command traces)
 twig list -vv
-2026-01-17 12:34:56.000 [DEBUG] git: git -C /Users/user/repo worktree list --porcelain
-/Users/user/repo                                   abc1234 [main]
-/Users/user/repo-worktree/feat/add-list-command    def5678 [feat/add-list-command]
-/Users/user/repo-worktree/feat/add-move-command    012abcd [feat/add-move-command]
+2026-01-17 12:34:56.000 [DEBUG] git: git -C ... worktree list --porcelain
+/Users/user/repo                abc1234 [main]
+/Users/user/repo-worktree/a     def5678 [feat/a]
+/Users/user/repo-worktree/b     012abcd [feat/b]
 ```
 
 ## Shell Integration

--- a/list.go
+++ b/list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"text/tabwriter"
 )
 
@@ -31,20 +32,29 @@ func NewDefaultListCommand(dir string, log *slog.Logger) *ListCommand {
 	return NewListCommand(NewGitRunner(dir, WithLogger(log)), log)
 }
 
-// ListResult holds the result of a list operation.
-type ListResult struct {
-	Worktrees []Worktree
+// ListWorktreeInfo holds a worktree and its additional status information.
+type ListWorktreeInfo struct {
+	Worktree
+	ChangedFiles []FileStatus
 }
 
-// ListFormatOptions configures list output formatting.
-type ListFormatOptions struct {
-	Quiet bool
+// ListResult holds the result of a list operation.
+type ListResult struct {
+	Worktrees []ListWorktreeInfo
+}
+
+// ListOptions configures the list operation.
+type ListOptions struct {
+	Verbose bool
 }
 
 // Format formats the ListResult for display.
-func (r ListResult) Format(opts ListFormatOptions) FormatResult {
+func (r ListResult) Format(opts FormatOptions) FormatResult {
 	if opts.Quiet {
 		return r.formatQuiet()
+	}
+	if opts.Verbose {
+		return r.formatVerbose()
 	}
 	return r.formatDefault()
 }
@@ -52,8 +62,8 @@ func (r ListResult) Format(opts ListFormatOptions) FormatResult {
 // formatQuiet outputs only the worktree paths.
 func (r ListResult) formatQuiet() FormatResult {
 	var stdout strings.Builder
-	for _, wt := range r.Worktrees {
-		stdout.WriteString(wt.Path)
+	for i := range r.Worktrees {
+		stdout.WriteString(r.Worktrees[i].Path)
 		stdout.WriteString("\n")
 	}
 	return FormatResult{Stdout: stdout.String()}
@@ -64,12 +74,46 @@ func (r ListResult) formatDefault() FormatResult {
 	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
 
-	for _, wt := range r.Worktrees {
+	for i := range r.Worktrees {
+		wt := &r.Worktrees[i]
 		fmt.Fprintf(w, "%s\t%s %s\n", wt.Path, wt.ShortHEAD(), wt.formatStatus())
 	}
 	w.Flush()
 
 	return FormatResult{Stdout: buf.String()}
+}
+
+// formatVerbose outputs worktrees with changed files and lock reasons.
+func (r ListResult) formatVerbose() FormatResult {
+	// Pass 1: generate aligned main lines with tabwriter
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+	for i := range r.Worktrees {
+		wt := &r.Worktrees[i]
+		fmt.Fprintf(w, "%s\t%s %s\n", wt.Path, wt.ShortHEAD(), wt.formatStatus())
+	}
+	w.Flush()
+
+	// Pass 2: interleave detail lines after each main line
+	mainLines := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
+	var stdout strings.Builder
+	for i := range r.Worktrees {
+		wt := &r.Worktrees[i]
+		if i < len(mainLines) {
+			stdout.WriteString(mainLines[i])
+			stdout.WriteString("\n")
+		}
+		// Lock reason
+		if wt.Locked && wt.LockReason != "" {
+			fmt.Fprintf(&stdout, "  lock reason: %s\n", wt.LockReason)
+		}
+		// Changed files
+		for _, f := range wt.ChangedFiles {
+			fmt.Fprintf(&stdout, "  %s %s\n", f.Status, f.Path)
+		}
+	}
+
+	return FormatResult{Stdout: stdout.String()}
 }
 
 // formatStatus returns the status portion of the worktree line (branch, locked, prunable).
@@ -98,11 +142,78 @@ func (w Worktree) formatStatus() string {
 }
 
 // Run lists all worktrees.
-func (c *ListCommand) Run(ctx context.Context) (ListResult, error) {
+func (c *ListCommand) Run(ctx context.Context, opts ListOptions) (ListResult, error) {
+	c.Log.DebugContext(ctx, "run started",
+		LogAttrKeyCategory.String(), LogCategoryList)
+
 	worktrees, err := c.Git.WorktreeList(ctx)
 	if err != nil {
 		return ListResult{}, err
 	}
 
-	return ListResult{Worktrees: worktrees}, nil
+	c.Log.DebugContext(ctx, "worktrees listed",
+		LogAttrKeyCategory.String(), LogCategoryList,
+		"count", len(worktrees))
+
+	infos := make([]ListWorktreeInfo, len(worktrees))
+	for i, wt := range worktrees {
+		infos[i] = ListWorktreeInfo{Worktree: wt}
+	}
+
+	// Fetch changed files in verbose mode
+	if opts.Verbose {
+		type indexedFiles struct {
+			index int
+			files []FileStatus
+		}
+
+		var (
+			wg      sync.WaitGroup
+			mu      sync.Mutex
+			results []indexedFiles
+		)
+
+		for i, wt := range worktrees {
+			// Skip bare and prunable worktrees (no working tree)
+			if wt.Bare || wt.Prunable {
+				continue
+			}
+
+			wg.Add(1)
+			go func(idx int, wt Worktree) {
+				defer wg.Done()
+
+				c.Log.DebugContext(ctx, "fetching changed files",
+					LogAttrKeyCategory.String(), LogCategoryList,
+					"path", wt.Path)
+
+				files, err := c.Git.InDir(wt.Path).ChangedFiles(ctx)
+				if err != nil {
+					c.Log.DebugContext(ctx, "failed to fetch changed files",
+						LogAttrKeyCategory.String(), LogCategoryList,
+						"path", wt.Path,
+						"error", err.Error())
+					return
+				}
+
+				if len(files) > 0 {
+					mu.Lock()
+					results = append(results, indexedFiles{index: idx, files: files})
+					mu.Unlock()
+				}
+			}(i, wt)
+		}
+
+		wg.Wait()
+
+		for _, r := range results {
+			infos[r.index].ChangedFiles = r.files
+		}
+	}
+
+	c.Log.DebugContext(ctx, "run completed",
+		LogAttrKeyCategory.String(), LogCategoryList,
+		"count", len(infos))
+
+	return ListResult{Worktrees: infos}, nil
 }

--- a/logger.go
+++ b/logger.go
@@ -164,6 +164,7 @@ const (
 	LogCategoryRemove = "remove"
 	LogCategoryClean  = "clean"
 	LogCategorySync   = "sync"
+	LogCategoryList   = "list"
 )
 
 // Command ID generation settings.

--- a/result.go
+++ b/result.go
@@ -1,7 +1,13 @@
 package twig
 
+import (
+	"fmt"
+	"strings"
+)
+
 // FormatOptions configures output formatting.
 type FormatOptions struct {
+	Quiet        bool
 	Verbose      bool
 	ColorEnabled bool // Enable color output (--color=auto/always)
 }
@@ -15,4 +21,16 @@ type FormatResult struct {
 // Formatter formats command results.
 type Formatter interface {
 	Format(opts FormatOptions) FormatResult
+}
+
+// lineWriter provides indented line writing for formatted output.
+type lineWriter struct {
+	w *strings.Builder
+}
+
+// Line writes a formatted line with the specified indentation level.
+// Each level adds 2 spaces of indentation.
+func (lw *lineWriter) Line(level int, format string, args ...any) {
+	fmt.Fprintf(lw.w, "%s"+format+"\n",
+		append([]any{strings.Repeat("  ", level)}, args...)...)
 }


### PR DESCRIPTION
## Overview

Add verbose output support to `twig list` command.

## Why

When managing multiple worktrees, users need to quickly see the status of each worktree without running separate `git status` commands. The verbose flag provides at-a-glance information about uncommitted changes and lock reasons.

## What

- Add `-v` flag to `twig list` to show per-worktree details
- Display uncommitted changed files (using `git status --porcelain` format) below each worktree line
- Display lock reasons for locked worktrees
- Fetch changed files in parallel across all worktrees
- Skip bare and prunable worktrees (no working tree to check)
- Refactor `FormatOptions` to support verbose mode and move `lineWriter` to `result.go`
- Add `ListWorktreeInfo` struct to hold worktree + changed files
- Add `ListOptions` struct to pass verbose flag to `Run()`
- Update CLI layer to propagate `-v` flag (quiet overrides verbose)

### Output example

```txt
twig list -v
/Users/user/repo              abc1234 [main]
/Users/user/repo-worktree/a   def5678 [feat/a]
   M src/main.go
  ?? tmp/debug.log
/Users/user/repo-worktree/usb 789abcd [feat/usb] locked
  lock reason: USB drive work
   M config.toml
```

## Type of Change

- [x] Feature

## How to Test

```bash
# Unit tests
go test ./...

# Integration tests
go test -tags=integration ./...

# Manual test
twig list -v
```

## Checklist

- [x] Tests added/updated
- [x] Self-reviewed
