### PR TITLE
feat: add overlay command for temporary file-level branch overlay

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "twig",
       "description": "Claude Code plugin for twig - simplifies git worktree workflows",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "category": "productivity",
       "keywords": ["git", "worktree", "branch", "cli", "twig"],
       "source": "./external/claude-code/plugins/twig"

--- a/cmd/twig/main.go
+++ b/cmd/twig/main.go
@@ -965,7 +965,7 @@ Examples:
 		Long: `Overlay file contents from a source branch onto a target worktree.
 
 This is useful for testing changes from a feature branch in the context
-of another worktree (e.g., running docker compose from the main worktree).
+of another worktree.
 
 Use --restore to return the target worktree to its original state.
 

--- a/cmd/twig/main.go
+++ b/cmd/twig/main.go
@@ -53,14 +53,20 @@ type SyncCommander interface {
 	Run(ctx context.Context, targets []string, cwd string, opts twig.SyncOptions) (twig.SyncResult, error)
 }
 
+// OverlayCommander defines the interface for overlay operations.
+type OverlayCommander interface {
+	Run(ctx context.Context, sourceBranch string, cwd string, opts twig.OverlayOptions) (twig.OverlayResult, error)
+}
+
 type options struct {
-	addCommander       AddCommander    // nil = use default
-	cleanCommander     CleanCommander  // nil = use default
-	listCommander      ListCommander   // nil = use default
-	removeCommander    RemoveCommander // nil = use default
-	initCommander      InitCommander   // nil = use default
-	syncCommander      SyncCommander   // nil = use default
-	commandIDGenerator func() string   // nil = use twig.GenerateCommandID
+	addCommander       AddCommander     // nil = use default
+	cleanCommander     CleanCommander   // nil = use default
+	listCommander      ListCommander    // nil = use default
+	removeCommander    RemoveCommander  // nil = use default
+	initCommander      InitCommander    // nil = use default
+	syncCommander      SyncCommander    // nil = use default
+	overlayCommander   OverlayCommander // nil = use default
+	commandIDGenerator func() string    // nil = use twig.GenerateCommandID
 }
 
 // Option configures newRootCmd.
@@ -105,6 +111,13 @@ func WithInitCommander(cmd InitCommander) Option {
 func WithSyncCommander(cmd SyncCommander) Option {
 	return func(o *options) {
 		o.syncCommander = cmd
+	}
+}
+
+// WithOverlayCommander sets the OverlayCommander instance for testing.
+func WithOverlayCommander(cmd OverlayCommander) Option {
+	return func(o *options) {
+		o.overlayCommander = cmd
 	}
 }
 
@@ -945,6 +958,123 @@ Examples:
 		return branches, cobra.ShellCompDirectiveNoFileComp
 	})
 	rootCmd.AddCommand(syncCmd)
+
+	overlayCmd := &cobra.Command{
+		Use:   "overlay [<source-branch>] [flags]",
+		Short: "Overlay file contents from another branch",
+		Long: `Overlay file contents from a source branch onto a target worktree.
+
+This is useful for testing changes from a feature branch in the context
+of another worktree (e.g., running docker compose from the main worktree).
+
+Use --restore to return the target worktree to its original state.
+
+Examples:
+  # Overlay feat/x onto main worktree
+  twig overlay feat/x --target main
+
+  # Overlay onto current worktree
+  twig overlay feat/x
+
+  # Restore original state
+  twig overlay --restore --target main
+
+  # Preview changes
+  twig overlay feat/x --target main --check`,
+		Args: cobra.MaximumNArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) >= 1 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			dir, err := resolveCompletionDirectory(cmd)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+			git := twig.NewGitRunner(dir)
+			branches, err := git.BranchList(cmd.Context())
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+			return branches, cobra.ShellCompDirectiveNoFileComp
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			restore, _ := cmd.Flags().GetBool("restore")
+			if restore && len(args) > 0 {
+				return fmt.Errorf("cannot specify source branch with --restore")
+			}
+			if !restore && len(args) == 0 {
+				return fmt.Errorf("source branch is required (or use --restore)")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			verbosity, _ := cmd.Flags().GetCount("verbose")
+			verbose := verbosity >= 1
+			quiet, _ := cmd.Flags().GetBool("quiet")
+			check, _ := cmd.Flags().GetBool("check")
+			restore, _ := cmd.Flags().GetBool("restore")
+			force, _ := cmd.Flags().GetBool("force")
+			target, _ := cmd.Flags().GetString("target")
+
+			idGen := twig.GenerateCommandID
+			if o.commandIDGenerator != nil {
+				idGen = o.commandIDGenerator
+			}
+			log := createLogger(cmd.ErrOrStderr(), verbosity, idGen)
+
+			opts := twig.OverlayOptions{
+				Restore: restore,
+				Check:   check,
+				Force:   force,
+				Target:  target,
+			}
+
+			var overlayCmdRunner OverlayCommander
+			if o.overlayCommander != nil {
+				overlayCmdRunner = o.overlayCommander
+			} else {
+				overlayCmdRunner = twig.NewDefaultOverlayCommand(cwd, log)
+			}
+
+			var sourceBranch string
+			if len(args) > 0 {
+				sourceBranch = args[0]
+			}
+
+			result, err := overlayCmdRunner.Run(cmd.Context(), sourceBranch, cwd, opts)
+			if err != nil {
+				return err
+			}
+
+			formatted := result.Format(twig.OverlayFormatOptions{
+				Verbose: verbose,
+				Quiet:   quiet,
+			})
+			if formatted.Stderr != "" {
+				fmt.Fprint(cmd.ErrOrStderr(), formatted.Stderr)
+			}
+			fmt.Fprint(cmd.OutOrStdout(), formatted.Stdout)
+			return nil
+		},
+	}
+	overlayCmd.Flags().Bool("restore", false, "Restore target worktree to original state")
+	overlayCmd.Flags().String("target", "", "Target worktree branch (default: current)")
+	overlayCmd.Flags().Bool("check", false, "Show what would be done (dry-run)")
+	overlayCmd.Flags().BoolP("force", "f", false, "Proceed even if target is dirty or HEAD has moved")
+	overlayCmd.Flags().BoolP("quiet", "q", false, "Suppress output")
+	overlayCmd.RegisterFlagCompletionFunc("target", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		dir, err := resolveCompletionDirectory(cmd)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		git := twig.NewGitRunner(dir)
+		branches, err := git.WorktreeListBranches(cmd.Context())
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		return branches, cobra.ShellCompDirectiveNoFileComp
+	})
+	rootCmd.AddCommand(overlayCmd)
 
 	versionCmd := &cobra.Command{
 		Use:   "version",

--- a/docs/reference/commands/overlay.md
+++ b/docs/reference/commands/overlay.md
@@ -37,42 +37,18 @@ worktree.
 2. Checks that no overlay is already active
 3. Checks that the target has no uncommitted changes (use `--force`
    to skip)
-4. Resolves the source branch to a commit hash
-5. Checks out source branch files onto the target: `git checkout
-   <source> -- .`
-6. Deletes files that exist in target HEAD but not in source
-7. Unstages all changes: `git reset HEAD`
-8. Writes a state file for later restore
+4. Overlays source branch files onto the target working tree
+5. Deletes files that exist in target HEAD but not in source
 
 ### Restore
 
-1. Reads the state file from the target's git directory
-2. Checks that HEAD hasn't moved since overlay (use `--force` to
+1. Checks that HEAD hasn't moved since overlay (use `--force` to
    skip)
-3. Restores tracked files from HEAD: `git checkout HEAD -- .`
-4. Removes only files that were added by the overlay
-5. Removes the state file
+2. Restores all tracked files to their original state
+3. Removes only files that were added by the overlay
 
 Files created by the user after overlay are preserved during restore.
 Only overlay-added files are removed.
-
-### State File
-
-The overlay state is stored at `<git-dir>/twig-overlay`:
-
-- Main worktree: `.git/twig-overlay`
-- Linked worktree: `.git/worktrees/<name>/twig-overlay`
-
-```json
-{
-  "source_branch": "feat/x",
-  "source_commit": "abc1234",
-  "target_branch": "main",
-  "target_commit": "def5678",
-  "added_files": ["new-file.go"],
-  "created_at": "2026-03-19T12:00:00Z"
-}
-```
 
 ### Safety: Commit Prevention
 

--- a/docs/reference/commands/overlay.md
+++ b/docs/reference/commands/overlay.md
@@ -29,7 +29,7 @@ twig overlay --restore [flags]          # Restore original state
 Overlays file contents from a source branch onto a target worktree
 without changing the target's checked-out branch. This is useful for
 testing changes from a feature branch in the context of another
-worktree (e.g., running docker compose from the main worktree).
+worktree.
 
 ### Apply
 
@@ -72,21 +72,6 @@ The overlay state is stored at `<git-dir>/twig-overlay`:
   "added_files": ["new-file.go"],
   "created_at": "2026-03-19T12:00:00Z"
 }
-```
-
-### Docker Compose Workflow
-
-```bash
-# Overlay feature branch onto main worktree
-twig overlay feat/x --target main
-
-# Run services (main worktree is synced to docker)
-docker compose up
-# ... test ...
-docker compose down
-
-# Restore main worktree
-twig overlay --restore --target main
 ```
 
 ### Safety: Commit Prevention

--- a/docs/reference/commands/overlay.md
+++ b/docs/reference/commands/overlay.md
@@ -1,0 +1,200 @@
+# overlay subcommand
+
+Overlay file contents from a source branch onto a target worktree.
+
+## Usage
+
+```txt
+twig overlay <source-branch> [flags]   # Apply overlay
+twig overlay --restore [flags]          # Restore original state
+```
+
+## Arguments
+
+- `<source-branch>`: Source branch to overlay (required for apply)
+
+## Flags
+
+| Flag        | Short | Description                                     |
+|-------------|-------|-------------------------------------------------|
+| `--restore` |       | Restore target worktree to original state       |
+| `--target`  |       | Target worktree branch (default: current)       |
+| `--check`   |       | Show what would be done (dry-run)               |
+| `--force`   | `-f`  | Proceed even if target is dirty or HEAD moved   |
+| `--quiet`   | `-q`  | Suppress output                                 |
+| `--verbose` | `-v`  | Verbose output (use `-vv` for debug)            |
+
+## Behavior
+
+Overlays file contents from a source branch onto a target worktree
+without changing the target's checked-out branch. This is useful for
+testing changes from a feature branch in the context of another
+worktree (e.g., running docker compose from the main worktree).
+
+### Apply
+
+1. Resolves the target worktree (from `--target` or current worktree)
+2. Checks that no overlay is already active
+3. Checks that the target has no uncommitted changes (use `--force`
+   to skip)
+4. Resolves the source branch to a commit hash
+5. Checks out source branch files onto the target: `git checkout
+   <source> -- .`
+6. Deletes files that exist in target HEAD but not in source
+7. Unstages all changes: `git reset HEAD`
+8. Writes a state file for later restore
+
+### Restore
+
+1. Reads the state file from the target's git directory
+2. Checks that HEAD hasn't moved since overlay (use `--force` to
+   skip)
+3. Restores tracked files from HEAD: `git checkout HEAD -- .`
+4. Removes only files that were added by the overlay
+5. Removes the state file
+
+Files created by the user after overlay are preserved during restore.
+Only overlay-added files are removed.
+
+### State File
+
+The overlay state is stored at `<git-dir>/twig-overlay`:
+
+- Main worktree: `.git/twig-overlay`
+- Linked worktree: `.git/worktrees/<name>/twig-overlay`
+
+```json
+{
+  "source_branch": "feat/x",
+  "source_commit": "abc1234",
+  "target_branch": "main",
+  "target_commit": "def5678",
+  "added_files": ["new-file.go"],
+  "created_at": "2026-03-19T12:00:00Z"
+}
+```
+
+### Docker Compose Workflow
+
+```bash
+# Overlay feature branch onto main worktree
+twig overlay feat/x --target main
+
+# Run services (main worktree is synced to docker)
+docker compose up
+# ... test ...
+docker compose down
+
+# Restore main worktree
+twig overlay --restore --target main
+```
+
+### Safety: Commit Prevention
+
+Overlay modifies the working tree without changing the branch.
+Committing in an overlaid worktree would commit the feature branch's
+content to the target branch (e.g., main).
+
+**Apply time:** A warning is printed to stderr:
+
+```txt
+warning: do not commit in the overlaid worktree.
+         Use 'twig overlay --restore' when done.
+```
+
+**Restore time:** HEAD movement is detected. If commits were made
+after overlay, restore fails with a hint:
+
+```txt
+error: HEAD has moved since overlay was applied
+hint: commits were made on the overlaid worktree
+hint: use 'git log --oneline <saved-commit>..HEAD' to review
+hint: use 'twig overlay --restore --force' to restore anyway
+```
+
+Use `--force` to restore anyway. Commits made after overlay remain
+in the git history (user can `git reset` if needed).
+
+### Force Option
+
+| Context         | `--force` behavior                      |
+|-----------------|-----------------------------------------|
+| Apply           | Proceeds even with uncommitted changes  |
+| Restore         | Proceeds even if HEAD has moved         |
+| Overlay stacked | Always refused (restore first)          |
+
+### Check Mode
+
+With `--check`, shows what would happen without making changes:
+
+```txt
+Would overlay main with feat/x:
+  42 file(s) would change
+  2 file(s) would be deleted
+  1 file(s) would be added
+```
+
+## Output Format
+
+### Apply (default)
+
+```txt
+Overlaid main with feat/x (42 files changed, 2 deleted, 1 added)
+```
+
+### Restore (default)
+
+```txt
+Restored main (removed overlay from feat/x)
+```
+
+### Verbose
+
+Verbose mode shows deleted and added file lists.
+
+### Quiet
+
+With `--quiet`, no output is produced.
+
+## Edge Cases
+
+| Case                          | Behavior                            |
+|-------------------------------|-------------------------------------|
+| Target has uncommitted changes | Refuse (use `--force`)             |
+| Overlay already active        | Refuse (restore first)             |
+| Source branch not found       | Error                               |
+| Source == target (same commit)| Error                               |
+| Restore when not overlaid     | Error                               |
+| User-created files on restore | Preserved                           |
+| Commits during overlay        | Detected on restore                 |
+| Submodules                    | Pointers updated, no init/deinit   |
+| Binary files                  | Handled by git checkout             |
+| Detached HEAD on target       | Works (recorded as "HEAD")          |
+
+## Examples
+
+```bash
+# Overlay feat/x onto main worktree
+twig overlay feat/x --target main
+
+# Overlay onto current worktree
+cd /path/to/main-worktree
+twig overlay feat/x
+
+# Preview changes
+twig overlay feat/x --target main --check
+
+# Force overlay on dirty worktree
+twig overlay feat/x --target main --force
+
+# Restore target worktree
+twig overlay --restore --target main
+
+# Force restore after accidental commit
+twig overlay --restore --target main --force
+```
+
+## Exit Code
+
+- 0: Success
+- 1: Error (dirty target, no overlay active, etc.)

--- a/docs/reference/commands/overlay.md
+++ b/docs/reference/commands/overlay.md
@@ -84,6 +84,11 @@ in the git history (user can `git reset` if needed).
 | Restore         | Proceeds even if HEAD has moved         |
 | Overlay stacked | Always refused (restore first)          |
 
+**Warning:** With `--force` on apply, uncommitted changes in tracked
+files are overwritten and cannot be recovered by `--restore`.
+Restore returns files to the last committed state, not the dirty
+state before overlay.
+
 ### Check Mode
 
 With `--check`, shows what would happen without making changes:

--- a/external/claude-code/plugins/twig/.claude-plugin/plugin.json
+++ b/external/claude-code/plugins/twig/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "twig",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Claude Code plugin for twig - simplifies git worktree workflows",
   "author": {
     "name": "708u"

--- a/external/claude-code/plugins/twig/skills/twig-guide/SKILL.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/SKILL.md
@@ -5,9 +5,10 @@ description: |
   - Wants to work on multiple branches simultaneously or in parallel
   - Needs to start a new feature/task while preserving current work
   - Asks about git worktree operations (create, remove, list, clean)
-  - Mentions "twig" commands (add, remove, clean, list, init)
+  - Mentions "twig" commands (add, remove, clean, list, init, overlay)
   - Wants to carry or move uncommitted changes to a new branch
   - Wants to copy/sync changes between branches
+  - Wants to temporarily apply another branch's files to a worktree
   - Needs to isolate work in a separate directory
   - Asks about switching context without stashing
   - Wants to clean up old/merged branches and their worktrees
@@ -36,6 +37,7 @@ creation, symlinks, and change management in a single command.
 | `twig list` | List all worktrees |
 | `twig clean` | Remove unneeded worktrees |
 | `twig sync` | Sync symlinks and submodules to worktrees |
+| `twig overlay` | Temporarily overlay another branch's files |
 
 ## Typical Workflows
 
@@ -90,6 +92,16 @@ twig clean
 This shows candidates and prompts for confirmation. Use `--yes` to skip
 the prompt.
 
+### Test a feature branch in another worktree
+
+Temporarily apply another branch's file contents:
+
+```bash
+twig overlay feat/x --target main
+# ... test in main worktree ...
+twig overlay --restore --target main
+```
+
 ### Force remove a worktree
 
 Remove a worktree even with uncommitted changes:
@@ -113,5 +125,6 @@ For detailed information on each command, refer to:
 - ./references/commands/list.md - List worktrees
 - ./references/commands/clean.md - Clean merged worktrees
 - ./references/commands/sync.md - Sync symlinks and submodules
+- ./references/commands/overlay.md - Overlay branch files temporarily
 - ./references/commands/init.md - Initialize configuration
 - ./references/configuration.md - Configuration file details

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/commands/overlay.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/commands/overlay.md
@@ -37,42 +37,18 @@ worktree.
 2. Checks that no overlay is already active
 3. Checks that the target has no uncommitted changes (use `--force`
    to skip)
-4. Resolves the source branch to a commit hash
-5. Checks out source branch files onto the target: `git checkout
-   <source> -- .`
-6. Deletes files that exist in target HEAD but not in source
-7. Unstages all changes: `git reset HEAD`
-8. Writes a state file for later restore
+4. Overlays source branch files onto the target working tree
+5. Deletes files that exist in target HEAD but not in source
 
 ### Restore
 
-1. Reads the state file from the target's git directory
-2. Checks that HEAD hasn't moved since overlay (use `--force` to
+1. Checks that HEAD hasn't moved since overlay (use `--force` to
    skip)
-3. Restores tracked files from HEAD: `git checkout HEAD -- .`
-4. Removes only files that were added by the overlay
-5. Removes the state file
+2. Restores all tracked files to their original state
+3. Removes only files that were added by the overlay
 
 Files created by the user after overlay are preserved during restore.
 Only overlay-added files are removed.
-
-### State File
-
-The overlay state is stored at `<git-dir>/twig-overlay`:
-
-- Main worktree: `.git/twig-overlay`
-- Linked worktree: `.git/worktrees/<name>/twig-overlay`
-
-```json
-{
-  "source_branch": "feat/x",
-  "source_commit": "abc1234",
-  "target_branch": "main",
-  "target_commit": "def5678",
-  "added_files": ["new-file.go"],
-  "created_at": "2026-03-19T12:00:00Z"
-}
-```
 
 ### Safety: Commit Prevention
 

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/commands/overlay.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/commands/overlay.md
@@ -29,7 +29,7 @@ twig overlay --restore [flags]          # Restore original state
 Overlays file contents from a source branch onto a target worktree
 without changing the target's checked-out branch. This is useful for
 testing changes from a feature branch in the context of another
-worktree (e.g., running docker compose from the main worktree).
+worktree.
 
 ### Apply
 
@@ -72,21 +72,6 @@ The overlay state is stored at `<git-dir>/twig-overlay`:
   "added_files": ["new-file.go"],
   "created_at": "2026-03-19T12:00:00Z"
 }
-```
-
-### Docker Compose Workflow
-
-```bash
-# Overlay feature branch onto main worktree
-twig overlay feat/x --target main
-
-# Run services (main worktree is synced to docker)
-docker compose up
-# ... test ...
-docker compose down
-
-# Restore main worktree
-twig overlay --restore --target main
 ```
 
 ### Safety: Commit Prevention

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/commands/overlay.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/commands/overlay.md
@@ -1,0 +1,200 @@
+# overlay subcommand
+
+Overlay file contents from a source branch onto a target worktree.
+
+## Usage
+
+```txt
+twig overlay <source-branch> [flags]   # Apply overlay
+twig overlay --restore [flags]          # Restore original state
+```
+
+## Arguments
+
+- `<source-branch>`: Source branch to overlay (required for apply)
+
+## Flags
+
+| Flag        | Short | Description                                     |
+|-------------|-------|-------------------------------------------------|
+| `--restore` |       | Restore target worktree to original state       |
+| `--target`  |       | Target worktree branch (default: current)       |
+| `--check`   |       | Show what would be done (dry-run)               |
+| `--force`   | `-f`  | Proceed even if target is dirty or HEAD moved   |
+| `--quiet`   | `-q`  | Suppress output                                 |
+| `--verbose` | `-v`  | Verbose output (use `-vv` for debug)            |
+
+## Behavior
+
+Overlays file contents from a source branch onto a target worktree
+without changing the target's checked-out branch. This is useful for
+testing changes from a feature branch in the context of another
+worktree (e.g., running docker compose from the main worktree).
+
+### Apply
+
+1. Resolves the target worktree (from `--target` or current worktree)
+2. Checks that no overlay is already active
+3. Checks that the target has no uncommitted changes (use `--force`
+   to skip)
+4. Resolves the source branch to a commit hash
+5. Checks out source branch files onto the target: `git checkout
+   <source> -- .`
+6. Deletes files that exist in target HEAD but not in source
+7. Unstages all changes: `git reset HEAD`
+8. Writes a state file for later restore
+
+### Restore
+
+1. Reads the state file from the target's git directory
+2. Checks that HEAD hasn't moved since overlay (use `--force` to
+   skip)
+3. Restores tracked files from HEAD: `git checkout HEAD -- .`
+4. Removes only files that were added by the overlay
+5. Removes the state file
+
+Files created by the user after overlay are preserved during restore.
+Only overlay-added files are removed.
+
+### State File
+
+The overlay state is stored at `<git-dir>/twig-overlay`:
+
+- Main worktree: `.git/twig-overlay`
+- Linked worktree: `.git/worktrees/<name>/twig-overlay`
+
+```json
+{
+  "source_branch": "feat/x",
+  "source_commit": "abc1234",
+  "target_branch": "main",
+  "target_commit": "def5678",
+  "added_files": ["new-file.go"],
+  "created_at": "2026-03-19T12:00:00Z"
+}
+```
+
+### Docker Compose Workflow
+
+```bash
+# Overlay feature branch onto main worktree
+twig overlay feat/x --target main
+
+# Run services (main worktree is synced to docker)
+docker compose up
+# ... test ...
+docker compose down
+
+# Restore main worktree
+twig overlay --restore --target main
+```
+
+### Safety: Commit Prevention
+
+Overlay modifies the working tree without changing the branch.
+Committing in an overlaid worktree would commit the feature branch's
+content to the target branch (e.g., main).
+
+**Apply time:** A warning is printed to stderr:
+
+```txt
+warning: do not commit in the overlaid worktree.
+         Use 'twig overlay --restore' when done.
+```
+
+**Restore time:** HEAD movement is detected. If commits were made
+after overlay, restore fails with a hint:
+
+```txt
+error: HEAD has moved since overlay was applied
+hint: commits were made on the overlaid worktree
+hint: use 'git log --oneline <saved-commit>..HEAD' to review
+hint: use 'twig overlay --restore --force' to restore anyway
+```
+
+Use `--force` to restore anyway. Commits made after overlay remain
+in the git history (user can `git reset` if needed).
+
+### Force Option
+
+| Context         | `--force` behavior                      |
+|-----------------|-----------------------------------------|
+| Apply           | Proceeds even with uncommitted changes  |
+| Restore         | Proceeds even if HEAD has moved         |
+| Overlay stacked | Always refused (restore first)          |
+
+### Check Mode
+
+With `--check`, shows what would happen without making changes:
+
+```txt
+Would overlay main with feat/x:
+  42 file(s) would change
+  2 file(s) would be deleted
+  1 file(s) would be added
+```
+
+## Output Format
+
+### Apply (default)
+
+```txt
+Overlaid main with feat/x (42 files changed, 2 deleted, 1 added)
+```
+
+### Restore (default)
+
+```txt
+Restored main (removed overlay from feat/x)
+```
+
+### Verbose
+
+Verbose mode shows deleted and added file lists.
+
+### Quiet
+
+With `--quiet`, no output is produced.
+
+## Edge Cases
+
+| Case                          | Behavior                            |
+|-------------------------------|-------------------------------------|
+| Target has uncommitted changes | Refuse (use `--force`)             |
+| Overlay already active        | Refuse (restore first)             |
+| Source branch not found       | Error                               |
+| Source == target (same commit)| Error                               |
+| Restore when not overlaid     | Error                               |
+| User-created files on restore | Preserved                           |
+| Commits during overlay        | Detected on restore                 |
+| Submodules                    | Pointers updated, no init/deinit   |
+| Binary files                  | Handled by git checkout             |
+| Detached HEAD on target       | Works (recorded as "HEAD")          |
+
+## Examples
+
+```bash
+# Overlay feat/x onto main worktree
+twig overlay feat/x --target main
+
+# Overlay onto current worktree
+cd /path/to/main-worktree
+twig overlay feat/x
+
+# Preview changes
+twig overlay feat/x --target main --check
+
+# Force overlay on dirty worktree
+twig overlay feat/x --target main --force
+
+# Restore target worktree
+twig overlay --restore --target main
+
+# Force restore after accidental commit
+twig overlay --restore --target main --force
+```
+
+## Exit Code
+
+- 0: Success
+- 1: Error (dirty target, no overlay active, etc.)

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/commands/overlay.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/commands/overlay.md
@@ -84,6 +84,11 @@ in the git history (user can `git reset` if needed).
 | Restore         | Proceeds even if HEAD has moved         |
 | Overlay stacked | Always refused (restore first)          |
 
+**Warning:** With `--force` on apply, uncommitted changes in tracked
+files are overwritten and cannot be recovered by `--restore`.
+Restore returns files to the last committed state, not the dirty
+state before overlay.
+
 ### Check Mode
 
 With `--check`, shows what would happen without making changes:

--- a/fs.go
+++ b/fs.go
@@ -18,6 +18,7 @@ type FileSystem interface {
 	ReadDir(name string) ([]os.DirEntry, error)
 	Remove(name string) error
 	WriteFile(name string, data []byte, perm fs.FileMode) error
+	ReadFile(name string) ([]byte, error)
 }
 
 type osFS struct{}
@@ -35,3 +36,4 @@ func (osFS) Remove(name string) error                     { return os.Remove(nam
 func (osFS) WriteFile(name string, data []byte, perm fs.FileMode) error {
 	return os.WriteFile(name, data, perm)
 }
+func (osFS) ReadFile(name string) ([]byte, error) { return os.ReadFile(name) }

--- a/git.go
+++ b/git.go
@@ -43,6 +43,8 @@ const (
 	GitCmdFetch      = "fetch"
 	GitCmdForEachRef = "for-each-ref"
 	GitCmdRevList    = "rev-list"
+	GitCmdCheckout   = "checkout"
+	GitCmdReset      = "reset"
 )
 
 // Git worktree subcommands.
@@ -941,6 +943,16 @@ func (g *GitRunner) SubmoduleUpdate(ctx context.Context, opts ...SubmoduleUpdate
 	}
 
 	return result, nil
+}
+
+// GitDir returns the worktree-specific git directory.
+// For the main worktree this is .git, for linked worktrees .git/worktrees/<name>.
+func (g *GitRunner) GitDir(ctx context.Context) (string, error) {
+	out, err := g.Run(ctx, GitCmdRevParse, "--path-format=absolute", "--git-dir")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 // MainWorktreePath returns the path of the main worktree.

--- a/internal/testutil/mock_fs.go
+++ b/internal/testutil/mock_fs.go
@@ -41,6 +41,7 @@ type MockFS struct {
 	ReadDirFunc    func(name string) ([]os.DirEntry, error)
 	RemoveFunc     func(name string) error
 	WriteFileFunc  func(name string, data []byte, perm fs.FileMode) error
+	ReadFileFunc   func(name string) ([]byte, error)
 
 	// ExistingPaths is a list of paths that exist (Stat returns nil, nil).
 	ExistingPaths []string
@@ -71,6 +72,12 @@ type MockFS struct {
 
 	// WrittenFiles records files written by WriteFile.
 	WrittenFiles map[string][]byte
+
+	// ReadFileResults maps path to file content.
+	ReadFileResults map[string][]byte
+
+	// ReadFileErr is returned by ReadFile if set.
+	ReadFileErr error
 }
 
 func (m *MockFS) Stat(name string) (fs.FileInfo, error) {
@@ -157,4 +164,24 @@ func (m *MockFS) WriteFile(name string, data []byte, perm fs.FileMode) error {
 		m.WrittenFiles[name] = data
 	}
 	return m.WriteFileErr
+}
+
+func (m *MockFS) ReadFile(name string) ([]byte, error) {
+	if m.ReadFileFunc != nil {
+		return m.ReadFileFunc(name)
+	}
+	if m.ReadFileErr != nil {
+		return nil, m.ReadFileErr
+	}
+	if m.ReadFileResults != nil {
+		if data, ok := m.ReadFileResults[name]; ok {
+			return data, nil
+		}
+	}
+	if m.WrittenFiles != nil {
+		if data, ok := m.WrittenFiles[name]; ok {
+			return data, nil
+		}
+	}
+	return nil, fs.ErrNotExist
 }

--- a/internal/testutil/mock_git.go
+++ b/internal/testutil/mock_git.go
@@ -124,6 +124,20 @@ type MockGitExecutor struct {
 
 	// RootCommits is a list of commits that have no parent (root commits).
 	RootCommits []string
+
+	// GitDirMap maps worktree directory to its git directory path.
+	// Used by rev-parse --git-dir.
+	GitDirMap map[string]string
+
+	// DiffNameOnlyOutput maps "filter:fromRef:toRef" to file list output.
+	// Used by git diff --name-only --diff-filter=X.
+	DiffNameOnlyOutput map[string]string
+
+	// CheckoutErr is returned when checkout is called.
+	CheckoutErr error
+
+	// ResetErr is returned when reset is called.
+	ResetErr error
 }
 
 func (m *MockGitExecutor) Run(ctx context.Context, args ...string) ([]byte, error) {
@@ -175,11 +189,33 @@ func (m *MockGitExecutor) defaultRun(args ...string) ([]byte, error) {
 		return m.handleSubmodule(args)
 	case "rev-list":
 		return m.handleRevList(args)
+	case "checkout":
+		return m.handleCheckout(args)
+	case "reset":
+		return m.handleReset(args)
+	case "diff":
+		return m.handleDiff(args)
 	}
 	return nil, nil
 }
 
 func (m *MockGitExecutor) handleRevParse(args []string, dir string) ([]byte, error) {
+	// Handle --git-dir for GitDir
+	for _, arg := range args[1:] {
+		if arg == "--git-dir" {
+			if m.GitDirMap != nil && dir != "" {
+				if gitDir, ok := m.GitDirMap[dir]; ok {
+					return []byte(gitDir + "\n"), nil
+				}
+			}
+			// Default: <dir>/.git
+			if dir != "" {
+				return []byte(dir + "/.git\n"), nil
+			}
+			return []byte(".git\n"), nil
+		}
+	}
+
 	// Handle --show-toplevel for WorktreeRoot
 	if len(args) >= 2 && args[1] == "--show-toplevel" {
 		// Look up the worktree root for the given directory
@@ -221,6 +257,20 @@ func (m *MockGitExecutor) handleRevParse(args []string, dir string) ([]byte, err
 	// Handle rev-parse <branch> (without --verify) for commit hash lookup
 	if len(args) == 2 && args[1] != "--verify" {
 		branch := args[1]
+
+		// Handle "HEAD" by finding the worktree for the current dir
+		if branch == "HEAD" && dir != "" {
+			for _, wt := range m.Worktrees {
+				if wt.Path == dir || strings.HasPrefix(dir, wt.Path+"/") {
+					head := wt.HEAD
+					if head == "" {
+						head = "commit-" + wt.Branch
+					}
+					return []byte(head + "\n"), nil
+				}
+			}
+		}
+
 		if m.BranchHEADs != nil {
 			if hash, ok := m.BranchHEADs[branch]; ok {
 				return []byte(hash + "\n"), nil
@@ -537,4 +587,43 @@ func (m *MockGitExecutor) handleRevList(args []string) ([]byte, error) {
 		return []byte{}, nil
 	}
 	return []byte(strings.Join(commits, "\n") + "\n"), nil
+}
+
+func (m *MockGitExecutor) handleCheckout(args []string) ([]byte, error) {
+	if m.CapturedArgs != nil {
+		*m.CapturedArgs = append(*m.CapturedArgs, args...)
+	}
+	return nil, m.CheckoutErr
+}
+
+func (m *MockGitExecutor) handleReset(args []string) ([]byte, error) {
+	if m.CapturedArgs != nil {
+		*m.CapturedArgs = append(*m.CapturedArgs, args...)
+	}
+	return nil, m.ResetErr
+}
+
+func (m *MockGitExecutor) handleDiff(args []string) ([]byte, error) {
+	if m.DiffNameOnlyOutput == nil {
+		return []byte{}, nil
+	}
+	// Build key from diff-filter and refs
+	// Expected args: ["diff", "--name-only", "--diff-filter=X", "from", "to"]
+	var filter, fromRef, toRef string
+	for _, arg := range args[1:] {
+		if strings.HasPrefix(arg, "--diff-filter=") {
+			filter = strings.TrimPrefix(arg, "--diff-filter=")
+		} else if !strings.HasPrefix(arg, "--") {
+			if fromRef == "" {
+				fromRef = arg
+			} else {
+				toRef = arg
+			}
+		}
+	}
+	key := filter + ":" + fromRef + ":" + toRef
+	if output, ok := m.DiffNameOnlyOutput[key]; ok {
+		return []byte(output), nil
+	}
+	return []byte{}, nil
 }

--- a/logger.go
+++ b/logger.go
@@ -157,13 +157,14 @@ const (
 
 // Log category values for consistent output prefixes.
 const (
-	LogCategoryDebug  = "debug"
-	LogCategoryGit    = "git"
-	LogCategoryConfig = "config"
-	LogCategoryGlob   = "glob"
-	LogCategoryRemove = "remove"
-	LogCategoryClean  = "clean"
-	LogCategorySync   = "sync"
+	LogCategoryDebug   = "debug"
+	LogCategoryGit     = "git"
+	LogCategoryConfig  = "config"
+	LogCategoryGlob    = "glob"
+	LogCategoryRemove  = "remove"
+	LogCategoryClean   = "clean"
+	LogCategorySync    = "sync"
+	LogCategoryOverlay = "overlay"
 )
 
 // Command ID generation settings.

--- a/overlay.go
+++ b/overlay.go
@@ -185,7 +185,14 @@ func (c *OverlayCommand) apply(ctx context.Context, sourceBranch string, cwd str
 	}
 
 	// Delete files that exist in target HEAD but not in source
-	c.removeFiles(ctx, targetPath, result.DeletedFiles)
+	for _, f := range result.DeletedFiles {
+		path := filepath.Join(targetPath, f)
+		if err := c.FS.Remove(path); err != nil && !c.FS.IsNotExist(err) {
+			c.Log.DebugContext(ctx, "failed to remove file",
+				LogAttrKeyCategory.String(), LogCategoryOverlay,
+				"file", f, "error", err)
+		}
+	}
 
 	// Unstage all changes
 	if _, err := targetGit.Run(ctx, GitCmdReset, "HEAD"); err != nil {
@@ -292,7 +299,14 @@ func (c *OverlayCommand) restore(ctx context.Context, cwd string, opts OverlayOp
 	}
 
 	// Remove files that were added by the overlay
-	c.removeFiles(ctx, targetPath, state.AddedFiles)
+	for _, f := range state.AddedFiles {
+		path := filepath.Join(targetPath, f)
+		if err := c.FS.Remove(path); err != nil && !c.FS.IsNotExist(err) {
+			c.Log.DebugContext(ctx, "failed to remove file",
+				LogAttrKeyCategory.String(), LogCategoryOverlay,
+				"file", f, "error", err)
+		}
+	}
 
 	// Remove state file
 	if err := c.FS.Remove(statePath); err != nil {
@@ -305,19 +319,6 @@ func (c *OverlayCommand) restore(ctx context.Context, cwd string, opts OverlayOp
 		"target", targetBranch)
 
 	return result, nil
-}
-
-// removeFiles removes a list of files from the target directory.
-// Errors are logged but do not stop the operation.
-func (c *OverlayCommand) removeFiles(ctx context.Context, targetPath string, files []string) {
-	for _, f := range files {
-		path := filepath.Join(targetPath, f)
-		if err := c.FS.Remove(path); err != nil && !c.FS.IsNotExist(err) {
-			c.Log.DebugContext(ctx, "failed to remove file",
-				LogAttrKeyCategory.String(), LogCategoryOverlay,
-				"file", f, "error", err)
-		}
-	}
 }
 
 // resolveTarget resolves the target worktree path and branch.

--- a/overlay.go
+++ b/overlay.go
@@ -1,0 +1,442 @@
+package twig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// OverlayCommand overlays file contents from a source branch onto a target worktree.
+type OverlayCommand struct {
+	FS  FileSystem
+	Git *GitRunner
+	Log *slog.Logger
+}
+
+// OverlayOptions configures the overlay operation.
+type OverlayOptions struct {
+	Restore bool   // Restore the target worktree to its original state
+	Check   bool   // Dry-run mode
+	Force   bool   // Proceed even if target is dirty or HEAD has moved
+	Target  string // Target branch (empty = current worktree)
+}
+
+// OverlayResult holds the result of an overlay operation.
+type OverlayResult struct {
+	SourceBranch  string
+	SourceCommit  string
+	TargetBranch  string
+	TargetPath    string
+	Restored      bool
+	Check         bool
+	ModifiedFiles int
+	DeletedFiles  []string
+	AddedFiles    []string
+}
+
+// OverlayFormatOptions configures overlay output formatting.
+type OverlayFormatOptions struct {
+	Verbose bool
+	Quiet   bool
+}
+
+// overlayState is persisted in the git directory to track active overlays.
+type overlayState struct {
+	SourceBranch string   `json:"source_branch"`
+	SourceCommit string   `json:"source_commit"`
+	TargetBranch string   `json:"target_branch"`
+	TargetCommit string   `json:"target_commit"`
+	AddedFiles   []string `json:"added_files,omitempty"`
+	CreatedAt    string   `json:"created_at"`
+}
+
+const overlayStateFile = "twig-overlay"
+
+// NewOverlayCommand creates an OverlayCommand with explicit dependencies.
+func NewOverlayCommand(fs FileSystem, git *GitRunner, log *slog.Logger) *OverlayCommand {
+	if log == nil {
+		log = NewNopLogger()
+	}
+	return &OverlayCommand{
+		FS:  fs,
+		Git: git,
+		Log: log,
+	}
+}
+
+// NewDefaultOverlayCommand creates an OverlayCommand with production defaults.
+func NewDefaultOverlayCommand(gitDir string, log *slog.Logger) *OverlayCommand {
+	return NewOverlayCommand(osFS{}, NewGitRunner(gitDir, WithLogger(log)), log)
+}
+
+// Run executes the overlay operation.
+func (c *OverlayCommand) Run(ctx context.Context, sourceBranch string, cwd string, opts OverlayOptions) (OverlayResult, error) {
+	if opts.Restore {
+		return c.restore(ctx, cwd, opts)
+	}
+	return c.apply(ctx, sourceBranch, cwd, opts)
+}
+
+// apply overlays the source branch content onto the target worktree.
+func (c *OverlayCommand) apply(ctx context.Context, sourceBranch string, cwd string, opts OverlayOptions) (OverlayResult, error) {
+	c.Log.DebugContext(ctx, "apply started",
+		LogAttrKeyCategory.String(), LogCategoryOverlay,
+		"source", sourceBranch,
+		"target", opts.Target,
+		"check", opts.Check,
+		"force", opts.Force)
+
+	var result OverlayResult
+	result.SourceBranch = sourceBranch
+	result.Check = opts.Check
+
+	// Resolve target worktree
+	targetPath, targetBranch, err := c.resolveTarget(ctx, cwd, opts.Target)
+	if err != nil {
+		return result, err
+	}
+	result.TargetBranch = targetBranch
+	result.TargetPath = targetPath
+
+	targetGit := c.Git.InDir(targetPath)
+
+	// Get target git directory (for state file)
+	gitDir, err := targetGit.GitDir(ctx)
+	if err != nil {
+		return result, fmt.Errorf("failed to get git directory: %w", err)
+	}
+
+	// Check for existing overlay
+	statePath := filepath.Join(gitDir, overlayStateFile)
+	if _, err := c.FS.Stat(statePath); err == nil {
+		return result, fmt.Errorf("overlay already active on %s\nhint: use 'twig overlay --restore' to restore first", targetBranch)
+	}
+
+	// Check for uncommitted changes
+	if !opts.Force {
+		hasChanges, err := targetGit.HasChanges(ctx)
+		if err != nil {
+			return result, fmt.Errorf("failed to check uncommitted changes: %w", err)
+		}
+		if hasChanges {
+			return result, fmt.Errorf("target worktree has uncommitted changes\nhint: use --force to proceed anyway")
+		}
+	}
+
+	// Resolve source commit
+	sourceCommitOut, err := targetGit.Run(ctx, GitCmdRevParse, sourceBranch)
+	if err != nil {
+		return result, fmt.Errorf("branch %q not found", sourceBranch)
+	}
+	sourceCommit := strings.TrimSpace(string(sourceCommitOut))
+	result.SourceCommit = sourceCommit
+
+	// Get target HEAD commit
+	targetCommitOut, err := targetGit.Run(ctx, GitCmdRevParse, "HEAD")
+	if err != nil {
+		return result, fmt.Errorf("failed to get target HEAD: %w", err)
+	}
+	targetCommit := strings.TrimSpace(string(targetCommitOut))
+
+	// Source == target check
+	if sourceCommit == targetCommit {
+		return result, fmt.Errorf("source and target are at the same commit")
+	}
+
+	// Get all changed files in a single diff, then filter by type.
+	// This avoids running three separate git diff commands.
+	allChangedOut, err := targetGit.Run(ctx, GitCmdDiff, "--name-only", "HEAD", sourceCommit)
+	if err != nil {
+		return result, fmt.Errorf("failed to diff: %w", err)
+	}
+	allChanged := splitNonEmpty(string(allChangedOut))
+	result.ModifiedFiles = len(allChanged)
+
+	// Identify deleted files (in HEAD but not in source)
+	deletedOut, err := targetGit.Run(ctx, GitCmdDiff, "--name-only", "--diff-filter=D", "HEAD", sourceCommit)
+	if err != nil {
+		return result, fmt.Errorf("failed to diff for deleted files: %w", err)
+	}
+	result.DeletedFiles = splitNonEmpty(string(deletedOut))
+
+	// Identify added files (in source but not in HEAD)
+	addedOut, err := targetGit.Run(ctx, GitCmdDiff, "--name-only", "--diff-filter=A", "HEAD", sourceCommit)
+	if err != nil {
+		return result, fmt.Errorf("failed to diff for added files: %w", err)
+	}
+	result.AddedFiles = splitNonEmpty(string(addedOut))
+
+	if opts.Check {
+		c.Log.DebugContext(ctx, "apply check completed",
+			LogAttrKeyCategory.String(), LogCategoryOverlay,
+			"modifiedFiles", result.ModifiedFiles,
+			"deletedFiles", len(result.DeletedFiles),
+			"addedFiles", len(result.AddedFiles))
+		return result, nil
+	}
+
+	// Checkout source branch files onto target
+	if _, err := targetGit.Run(ctx, GitCmdCheckout, sourceBranch, "--", "."); err != nil {
+		return result, fmt.Errorf("failed to checkout source files: %w", err)
+	}
+
+	// Delete files that exist in target HEAD but not in source
+	c.removeFiles(ctx, targetPath, result.DeletedFiles)
+
+	// Unstage all changes
+	if _, err := targetGit.Run(ctx, GitCmdReset, "HEAD"); err != nil {
+		return result, fmt.Errorf("failed to unstage changes: %w", err)
+	}
+
+	// Write state file
+	state := overlayState{
+		SourceBranch: sourceBranch,
+		SourceCommit: sourceCommit,
+		TargetBranch: targetBranch,
+		TargetCommit: targetCommit,
+		AddedFiles:   result.AddedFiles,
+		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
+	}
+	stateData, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return result, fmt.Errorf("failed to marshal state: %w", err)
+	}
+	if err := c.FS.WriteFile(statePath, stateData, 0644); err != nil {
+		return result, fmt.Errorf("failed to write state file: %w", err)
+	}
+
+	c.Log.DebugContext(ctx, "apply completed",
+		LogAttrKeyCategory.String(), LogCategoryOverlay,
+		"source", sourceBranch,
+		"target", targetBranch,
+		"modifiedFiles", result.ModifiedFiles)
+
+	return result, nil
+}
+
+// restore removes the overlay and returns the target worktree to its original state.
+func (c *OverlayCommand) restore(ctx context.Context, cwd string, opts OverlayOptions) (OverlayResult, error) {
+	c.Log.DebugContext(ctx, "restore started",
+		LogAttrKeyCategory.String(), LogCategoryOverlay,
+		"target", opts.Target,
+		"check", opts.Check,
+		"force", opts.Force)
+
+	var result OverlayResult
+	result.Restored = true
+	result.Check = opts.Check
+
+	// Resolve target worktree
+	targetPath, targetBranch, err := c.resolveTarget(ctx, cwd, opts.Target)
+	if err != nil {
+		return result, err
+	}
+	result.TargetBranch = targetBranch
+	result.TargetPath = targetPath
+
+	targetGit := c.Git.InDir(targetPath)
+
+	// Get git directory
+	gitDir, err := targetGit.GitDir(ctx)
+	if err != nil {
+		return result, fmt.Errorf("failed to get git directory: %w", err)
+	}
+
+	// Read state file
+	statePath := filepath.Join(gitDir, overlayStateFile)
+	stateData, err := c.FS.ReadFile(statePath)
+	if err != nil {
+		return result, fmt.Errorf("no overlay active on %s", targetBranch)
+	}
+
+	var state overlayState
+	if err := json.Unmarshal(stateData, &state); err != nil {
+		return result, fmt.Errorf("failed to parse state file: %w", err)
+	}
+	result.SourceBranch = state.SourceBranch
+	result.SourceCommit = state.SourceCommit
+	result.AddedFiles = state.AddedFiles
+
+	// Check if HEAD has moved since overlay
+	currentHEAD, err := targetGit.Run(ctx, GitCmdRevParse, "HEAD")
+	if err != nil {
+		return result, fmt.Errorf("failed to get current HEAD: %w", err)
+	}
+	if strings.TrimSpace(string(currentHEAD)) != state.TargetCommit {
+		if !opts.Force {
+			return result, fmt.Errorf(
+				"HEAD has moved since overlay was applied\n"+
+					"hint: commits were made on the overlaid worktree\n"+
+					"hint: use 'git log --oneline %s..HEAD' to review\n"+
+					"hint: use 'twig overlay --restore --force' to restore anyway",
+				state.TargetCommit)
+		}
+		c.Log.DebugContext(ctx, "HEAD moved but --force specified",
+			LogAttrKeyCategory.String(), LogCategoryOverlay)
+	}
+
+	if opts.Check {
+		c.Log.DebugContext(ctx, "restore check completed",
+			LogAttrKeyCategory.String(), LogCategoryOverlay,
+			"source", state.SourceBranch)
+		return result, nil
+	}
+
+	// Restore tracked files from HEAD
+	if _, err := targetGit.Run(ctx, GitCmdCheckout, "HEAD", "--", "."); err != nil {
+		return result, fmt.Errorf("failed to restore tracked files: %w", err)
+	}
+
+	// Remove files that were added by the overlay
+	c.removeFiles(ctx, targetPath, state.AddedFiles)
+
+	// Remove state file
+	if err := c.FS.Remove(statePath); err != nil {
+		return result, fmt.Errorf("failed to remove state file: %w", err)
+	}
+
+	c.Log.DebugContext(ctx, "restore completed",
+		LogAttrKeyCategory.String(), LogCategoryOverlay,
+		"source", state.SourceBranch,
+		"target", targetBranch)
+
+	return result, nil
+}
+
+// removeFiles removes a list of files from the target directory.
+// Errors are logged but do not stop the operation.
+func (c *OverlayCommand) removeFiles(ctx context.Context, targetPath string, files []string) {
+	for _, f := range files {
+		path := filepath.Join(targetPath, f)
+		if err := c.FS.Remove(path); err != nil && !c.FS.IsNotExist(err) {
+			c.Log.DebugContext(ctx, "failed to remove file",
+				LogAttrKeyCategory.String(), LogCategoryOverlay,
+				"file", f, "error", err)
+		}
+	}
+}
+
+// resolveTarget resolves the target worktree path and branch.
+func (c *OverlayCommand) resolveTarget(ctx context.Context, cwd, target string) (string, string, error) {
+	if target != "" {
+		wt, err := c.Git.WorktreeFindByBranch(ctx, target)
+		if err != nil {
+			return "", "", fmt.Errorf("target worktree not found: %w", err)
+		}
+		return wt.Path, wt.Branch, nil
+	}
+
+	// Use current worktree
+	root, err := c.Git.InDir(cwd).WorktreeRoot(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("current directory is not in any worktree: %w", err)
+	}
+
+	worktrees, err := c.Git.WorktreeList(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to list worktrees: %w", err)
+	}
+	for _, wt := range worktrees {
+		if wt.Path == root {
+			branch := wt.Branch
+			if branch == "" {
+				branch = "HEAD"
+			}
+			return wt.Path, branch, nil
+		}
+	}
+	return "", "", fmt.Errorf("current directory is not in any worktree")
+}
+
+// Format formats the OverlayResult for display.
+func (r OverlayResult) Format(opts OverlayFormatOptions) FormatResult {
+	if opts.Quiet {
+		return FormatResult{}
+	}
+
+	var stdout, stderr strings.Builder
+
+	if r.Check {
+		if r.Restored {
+			fmt.Fprintf(&stdout, "Would restore %s (remove overlay from %s)\n", r.TargetBranch, r.SourceBranch)
+			if len(r.AddedFiles) > 0 {
+				fmt.Fprintf(&stdout, "  %d overlay-added file(s) would be removed\n", len(r.AddedFiles))
+			}
+		} else {
+			fmt.Fprintf(&stdout, "Would overlay %s with %s:\n", r.TargetBranch, r.SourceBranch)
+			fmt.Fprintf(&stdout, "  %d file(s) would change\n", r.ModifiedFiles)
+			if len(r.DeletedFiles) > 0 {
+				fmt.Fprintf(&stdout, "  %d file(s) would be deleted\n", len(r.DeletedFiles))
+			}
+			if len(r.AddedFiles) > 0 {
+				fmt.Fprintf(&stdout, "  %d file(s) would be added\n", len(r.AddedFiles))
+			}
+		}
+
+		if opts.Verbose {
+			if len(r.DeletedFiles) > 0 {
+				fmt.Fprintln(&stdout, "Deleted files:")
+				for _, f := range r.DeletedFiles {
+					fmt.Fprintf(&stdout, "  %s\n", f)
+				}
+			}
+			if len(r.AddedFiles) > 0 {
+				fmt.Fprintln(&stdout, "Added files:")
+				for _, f := range r.AddedFiles {
+					fmt.Fprintf(&stdout, "  %s\n", f)
+				}
+			}
+		}
+		return FormatResult{Stdout: stdout.String(), Stderr: stderr.String()}
+	}
+
+	if r.Restored {
+		fmt.Fprintf(&stdout, "Restored %s (removed overlay from %s)\n", r.TargetBranch, r.SourceBranch)
+	} else {
+		fmt.Fprintf(&stdout, "Overlaid %s with %s", r.TargetBranch, r.SourceBranch)
+		fmt.Fprintf(&stdout, " (%d files changed", r.ModifiedFiles)
+		if len(r.DeletedFiles) > 0 {
+			fmt.Fprintf(&stdout, ", %d deleted", len(r.DeletedFiles))
+		}
+		if len(r.AddedFiles) > 0 {
+			fmt.Fprintf(&stdout, ", %d added", len(r.AddedFiles))
+		}
+		fmt.Fprintln(&stdout, ")")
+
+		// Warning about not committing
+		fmt.Fprintln(&stderr, "warning: do not commit in the overlaid worktree.")
+		fmt.Fprintln(&stderr, "         Use 'twig overlay --restore' when done.")
+	}
+
+	if opts.Verbose {
+		if len(r.DeletedFiles) > 0 {
+			fmt.Fprintln(&stdout, "Deleted files:")
+			for _, f := range r.DeletedFiles {
+				fmt.Fprintf(&stdout, "  %s\n", f)
+			}
+		}
+		if len(r.AddedFiles) > 0 {
+			fmt.Fprintln(&stdout, "Added files:")
+			for _, f := range r.AddedFiles {
+				fmt.Fprintf(&stdout, "  %s\n", f)
+			}
+		}
+	}
+
+	return FormatResult{Stdout: stdout.String(), Stderr: stderr.String()}
+}
+
+// splitNonEmpty splits a newline-separated string and removes empty entries.
+func splitNonEmpty(s string) []string {
+	var result []string
+	for _, line := range strings.Split(strings.TrimSpace(s), "\n") {
+		if line != "" {
+			result = append(result, line)
+		}
+	}
+	return result
+}

--- a/overlay.go
+++ b/overlay.go
@@ -123,7 +123,7 @@ func (c *OverlayCommand) apply(ctx context.Context, sourceBranch string, cwd str
 			return result, fmt.Errorf("failed to check uncommitted changes: %w", err)
 		}
 		if hasChanges {
-			return result, fmt.Errorf("target worktree has uncommitted changes\nhint: use --force to proceed anyway")
+			return result, fmt.Errorf("target worktree has uncommitted changes\nhint: use --force to proceed (uncommitted changes will be lost)")
 		}
 	}
 

--- a/overlay_integration_test.go
+++ b/overlay_integration_test.go
@@ -226,6 +226,179 @@ func TestOverlay_Integration(t *testing.T) {
 		}
 	})
 
+	t.Run("ForceOverlayOnDirtyTarget", func(t *testing.T) {
+		t.Parallel()
+
+		_, mainDir := testutil.SetupTestRepo(t)
+
+		writeFile(t, mainDir, "file.txt", "original")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "add file")
+
+		testutil.RunGit(t, mainDir, "checkout", "-b", "feat/f")
+		writeFile(t, mainDir, "file.txt", "feature")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "feature change")
+
+		testutil.RunGit(t, mainDir, "checkout", "main")
+
+		// Make target dirty
+		writeFile(t, mainDir, "file.txt", "dirty local edit")
+
+		git := NewGitRunner(mainDir)
+		cmd := NewOverlayCommand(osFS{}, git, nil)
+
+		// Without --force: should refuse
+		_, err := cmd.Run(t.Context(), "feat/f", mainDir, OverlayOptions{})
+		if err == nil {
+			t.Fatal("expected error for dirty target")
+		}
+		if !strings.Contains(err.Error(), "uncommitted changes") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// With --force: should succeed
+		_, err = cmd.Run(t.Context(), "feat/f", mainDir, OverlayOptions{Force: true})
+		if err != nil {
+			t.Fatalf("force apply failed: %v", err)
+		}
+
+		// Verify overlay applied
+		content := readFile(t, mainDir, "file.txt")
+		if content != "feature" {
+			t.Errorf("file.txt = %q after overlay, want 'feature'", content)
+		}
+
+		// Restore should work
+		_, err = cmd.Run(t.Context(), "", mainDir, OverlayOptions{Restore: true})
+		if err != nil {
+			t.Fatalf("restore failed: %v", err)
+		}
+
+		// file.txt restored to committed state (dirty edit is lost,
+		// which is the expected --force trade-off)
+		content = readFile(t, mainDir, "file.txt")
+		if content != "original" {
+			t.Errorf("file.txt = %q after restore, want 'original'", content)
+		}
+	})
+
+	t.Run("HeadMovedDuringOverlay", func(t *testing.T) {
+		t.Parallel()
+
+		_, mainDir := testutil.SetupTestRepo(t)
+
+		writeFile(t, mainDir, "file.txt", "main")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "add file")
+
+		testutil.RunGit(t, mainDir, "checkout", "-b", "feat/h")
+		writeFile(t, mainDir, "file.txt", "feature")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "feature")
+
+		testutil.RunGit(t, mainDir, "checkout", "main")
+
+		git := NewGitRunner(mainDir)
+		cmd := NewOverlayCommand(osFS{}, git, nil)
+
+		// Apply overlay
+		_, err := cmd.Run(t.Context(), "feat/h", mainDir, OverlayOptions{})
+		if err != nil {
+			t.Fatalf("apply failed: %v", err)
+		}
+
+		// Simulate accidental commit (empty commit moves HEAD)
+		testutil.RunGit(t, mainDir, "commit", "--allow-empty", "-m", "accidental")
+
+		// Restore without --force: should detect HEAD movement
+		_, err = cmd.Run(t.Context(), "", mainDir, OverlayOptions{Restore: true})
+		if err == nil {
+			t.Fatal("expected error for HEAD movement")
+		}
+		if !strings.Contains(err.Error(), "HEAD has moved") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Restore with --force: should succeed
+		_, err = cmd.Run(t.Context(), "", mainDir, OverlayOptions{Restore: true, Force: true})
+		if err != nil {
+			t.Fatalf("force restore failed: %v", err)
+		}
+
+		// File should be restored
+		content := readFile(t, mainDir, "file.txt")
+		if content != "main" {
+			t.Errorf("file.txt = %q after force restore, want 'main'", content)
+		}
+
+		// State file should be removed
+		gitDirOut := strings.TrimSpace(testutil.RunGit(t, mainDir, "rev-parse", "--path-format=absolute", "--git-dir"))
+		statePath := filepath.Join(gitDirOut, "twig-overlay")
+		if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+			t.Error("state file should be removed after force restore")
+		}
+	})
+
+	t.Run("OverlayStackingBlocked", func(t *testing.T) {
+		t.Parallel()
+
+		_, mainDir := testutil.SetupTestRepo(t)
+
+		writeFile(t, mainDir, "file.txt", "main")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "add file")
+
+		testutil.RunGit(t, mainDir, "checkout", "-b", "feat/s1")
+		writeFile(t, mainDir, "file.txt", "s1")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "s1")
+
+		testutil.RunGit(t, mainDir, "checkout", "main")
+		testutil.RunGit(t, mainDir, "checkout", "-b", "feat/s2")
+		writeFile(t, mainDir, "file.txt", "s2")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "s2")
+
+		testutil.RunGit(t, mainDir, "checkout", "main")
+
+		git := NewGitRunner(mainDir)
+		cmd := NewOverlayCommand(osFS{}, git, nil)
+
+		// First overlay
+		_, err := cmd.Run(t.Context(), "feat/s1", mainDir, OverlayOptions{})
+		if err != nil {
+			t.Fatalf("first overlay failed: %v", err)
+		}
+
+		// Second overlay with same source: blocked
+		_, err = cmd.Run(t.Context(), "feat/s1", mainDir, OverlayOptions{})
+		if err == nil {
+			t.Fatal("expected error for stacking same source")
+		}
+		if !strings.Contains(err.Error(), "overlay already active") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Second overlay with different source: also blocked
+		_, err = cmd.Run(t.Context(), "feat/s2", mainDir, OverlayOptions{})
+		if err == nil {
+			t.Fatal("expected error for stacking different source")
+		}
+
+		// Even with --force: stacking blocked
+		_, err = cmd.Run(t.Context(), "feat/s2", mainDir, OverlayOptions{Force: true})
+		if err == nil {
+			t.Fatal("expected error for stacking with --force")
+		}
+
+		// Clean up: restore first overlay
+		_, err = cmd.Run(t.Context(), "", mainDir, OverlayOptions{Restore: true})
+		if err != nil {
+			t.Fatalf("restore failed: %v", err)
+		}
+	})
+
 	t.Run("StateFilePersistence", func(t *testing.T) {
 		t.Parallel()
 

--- a/overlay_integration_test.go
+++ b/overlay_integration_test.go
@@ -1,0 +1,297 @@
+//go:build integration
+
+package twig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/708u/twig/internal/testutil"
+)
+
+func TestOverlay_Integration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ApplyAndRestore", func(t *testing.T) {
+		t.Parallel()
+
+		_, mainDir := testutil.SetupTestRepo(t)
+
+		// Create a file on main
+		writeFile(t, mainDir, "main-only.txt", "main content")
+		writeFile(t, mainDir, "shared.txt", "original content")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "add files on main")
+
+		// Create feature branch with changes
+		testutil.RunGit(t, mainDir, "checkout", "-b", "feat/x")
+		writeFile(t, mainDir, "shared.txt", "feature content")
+		writeFile(t, mainDir, "feat-only.txt", "feature file")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "feature changes")
+
+		// Switch back to main
+		testutil.RunGit(t, mainDir, "checkout", "main")
+
+		// Apply overlay
+		git := NewGitRunner(mainDir)
+		cmd := NewOverlayCommand(osFS{}, git, nil)
+
+		result, err := cmd.Run(t.Context(), "feat/x", mainDir, OverlayOptions{})
+		if err != nil {
+			t.Fatalf("apply failed: %v", err)
+		}
+
+		if result.SourceBranch != "feat/x" {
+			t.Errorf("SourceBranch = %q, want feat/x", result.SourceBranch)
+		}
+		if result.ModifiedFiles == 0 {
+			t.Error("expected modified files")
+		}
+
+		// Verify overlay: shared.txt should have feature content
+		content := readFile(t, mainDir, "shared.txt")
+		if content != "feature content" {
+			t.Errorf("shared.txt = %q, want 'feature content'", content)
+		}
+
+		// feat-only.txt should exist
+		if !fileExists(t, mainDir, "feat-only.txt") {
+			t.Error("feat-only.txt should exist after overlay")
+		}
+
+		// Still on main branch
+		branch := strings.TrimSpace(testutil.RunGit(t, mainDir, "rev-parse", "--abbrev-ref", "HEAD"))
+		if branch != "main" {
+			t.Errorf("branch = %q, want main", branch)
+		}
+
+		// No staged changes (unstaged by reset HEAD)
+		staged := testutil.RunGit(t, mainDir, "diff", "--cached", "--name-only")
+		if strings.TrimSpace(staged) != "" {
+			t.Errorf("unexpected staged changes: %s", staged)
+		}
+
+		// Restore
+		restoreResult, err := cmd.Run(t.Context(), "", mainDir, OverlayOptions{Restore: true})
+		if err != nil {
+			t.Fatalf("restore failed: %v", err)
+		}
+		if !restoreResult.Restored {
+			t.Error("expected Restored=true")
+		}
+
+		// Verify restore: shared.txt should be back to original
+		content = readFile(t, mainDir, "shared.txt")
+		if content != "original content" {
+			t.Errorf("shared.txt = %q after restore, want 'original content'", content)
+		}
+
+		// feat-only.txt should be gone
+		if fileExists(t, mainDir, "feat-only.txt") {
+			t.Error("feat-only.txt should not exist after restore")
+		}
+	})
+
+	t.Run("WithDeletedFiles", func(t *testing.T) {
+		t.Parallel()
+
+		_, mainDir := testutil.SetupTestRepo(t)
+
+		// Create files on main
+		writeFile(t, mainDir, "keep.txt", "keep")
+		writeFile(t, mainDir, "delete-me.txt", "will be deleted")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "add files")
+
+		// Create feature branch that deletes a file
+		testutil.RunGit(t, mainDir, "checkout", "-b", "feat/del")
+		testutil.RunGit(t, mainDir, "rm", "delete-me.txt")
+		testutil.RunGit(t, mainDir, "commit", "-m", "delete file")
+
+		// Switch back to main
+		testutil.RunGit(t, mainDir, "checkout", "main")
+
+		git := NewGitRunner(mainDir)
+		cmd := NewOverlayCommand(osFS{}, git, nil)
+
+		// Apply overlay
+		result, err := cmd.Run(t.Context(), "feat/del", mainDir, OverlayOptions{})
+		if err != nil {
+			t.Fatalf("apply failed: %v", err)
+		}
+
+		// delete-me.txt should be deleted
+		if fileExists(t, mainDir, "delete-me.txt") {
+			t.Error("delete-me.txt should be deleted after overlay")
+		}
+		if len(result.DeletedFiles) == 0 {
+			t.Error("expected deleted files in result")
+		}
+
+		// Restore
+		_, err = cmd.Run(t.Context(), "", mainDir, OverlayOptions{Restore: true})
+		if err != nil {
+			t.Fatalf("restore failed: %v", err)
+		}
+
+		// delete-me.txt should be back
+		if !fileExists(t, mainDir, "delete-me.txt") {
+			t.Error("delete-me.txt should exist after restore")
+		}
+	})
+
+	t.Run("WithNewFiles", func(t *testing.T) {
+		t.Parallel()
+
+		_, mainDir := testutil.SetupTestRepo(t)
+
+		// Create file on main
+		writeFile(t, mainDir, "existing.txt", "existing")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "add file")
+
+		// Create feature branch with new file
+		testutil.RunGit(t, mainDir, "checkout", "-b", "feat/new")
+		writeFile(t, mainDir, "brand-new.txt", "new content")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "add new file")
+
+		testutil.RunGit(t, mainDir, "checkout", "main")
+
+		git := NewGitRunner(mainDir)
+		cmd := NewOverlayCommand(osFS{}, git, nil)
+
+		result, err := cmd.Run(t.Context(), "feat/new", mainDir, OverlayOptions{})
+		if err != nil {
+			t.Fatalf("apply failed: %v", err)
+		}
+
+		// brand-new.txt should appear
+		if !fileExists(t, mainDir, "brand-new.txt") {
+			t.Error("brand-new.txt should exist after overlay")
+		}
+		if len(result.AddedFiles) == 0 {
+			t.Error("expected added files in result")
+		}
+
+		// Restore should remove it
+		_, err = cmd.Run(t.Context(), "", mainDir, OverlayOptions{Restore: true})
+		if err != nil {
+			t.Fatalf("restore failed: %v", err)
+		}
+		if fileExists(t, mainDir, "brand-new.txt") {
+			t.Error("brand-new.txt should not exist after restore")
+		}
+	})
+
+	t.Run("PreservesUserFiles", func(t *testing.T) {
+		t.Parallel()
+
+		_, mainDir := testutil.SetupTestRepo(t)
+
+		writeFile(t, mainDir, "main.txt", "main")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "add main.txt")
+
+		testutil.RunGit(t, mainDir, "checkout", "-b", "feat/y")
+		writeFile(t, mainDir, "main.txt", "modified")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "modify")
+
+		testutil.RunGit(t, mainDir, "checkout", "main")
+
+		git := NewGitRunner(mainDir)
+		cmd := NewOverlayCommand(osFS{}, git, nil)
+
+		_, err := cmd.Run(t.Context(), "feat/y", mainDir, OverlayOptions{})
+		if err != nil {
+			t.Fatalf("apply failed: %v", err)
+		}
+
+		// User creates a debug file after overlay
+		writeFile(t, mainDir, "debug.log", "user debug")
+
+		// Restore
+		_, err = cmd.Run(t.Context(), "", mainDir, OverlayOptions{Restore: true})
+		if err != nil {
+			t.Fatalf("restore failed: %v", err)
+		}
+
+		// debug.log should be preserved
+		if !fileExists(t, mainDir, "debug.log") {
+			t.Error("user-created debug.log should be preserved after restore")
+		}
+	})
+
+	t.Run("StateFilePersistence", func(t *testing.T) {
+		t.Parallel()
+
+		_, mainDir := testutil.SetupTestRepo(t)
+
+		writeFile(t, mainDir, "file.txt", "content")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "add file")
+
+		testutil.RunGit(t, mainDir, "checkout", "-b", "feat/z")
+		writeFile(t, mainDir, "file.txt", "changed")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "change file")
+
+		testutil.RunGit(t, mainDir, "checkout", "main")
+
+		git := NewGitRunner(mainDir)
+		cmd := NewOverlayCommand(osFS{}, git, nil)
+
+		_, err := cmd.Run(t.Context(), "feat/z", mainDir, OverlayOptions{})
+		if err != nil {
+			t.Fatalf("apply failed: %v", err)
+		}
+
+		// State file should exist in .git directory
+		gitDirOut := strings.TrimSpace(testutil.RunGit(t, mainDir, "rev-parse", "--path-format=absolute", "--git-dir"))
+		statePath := filepath.Join(gitDirOut, "twig-overlay")
+		if _, err := os.Stat(statePath); os.IsNotExist(err) {
+			t.Errorf("state file not found at %s", statePath)
+		}
+
+		// Restore and verify state file is removed
+		_, err = cmd.Run(t.Context(), "", mainDir, OverlayOptions{Restore: true})
+		if err != nil {
+			t.Fatalf("restore failed: %v", err)
+		}
+		if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+			t.Error("state file should be removed after restore")
+		}
+	})
+}
+
+// Test helpers
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, dir, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func fileExists(t *testing.T, dir, name string) bool {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(dir, name))
+	return err == nil
+}

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -1,0 +1,574 @@
+package twig
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/708u/twig/internal/testutil"
+)
+
+func TestOverlayCommand_Apply(t *testing.T) {
+	t.Parallel()
+
+	t.Run("BasicApply", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "main-commit-abc"},
+				{Path: "/repo/feat-x", Branch: "feat/x", HEAD: "feat-x-commit-def"},
+			},
+			BranchHEADs: map[string]string{
+				"feat/x": "feat-x-commit-def",
+			},
+			DiffNameOnlyOutput: map[string]string{
+				"D:HEAD:feat-x-commit-def": "old-file.txt\n",
+				"A:HEAD:feat-x-commit-def": "new-file.go\n",
+				":HEAD:feat-x-commit-def":  "main.go\nold-file.txt\nnew-file.go\n",
+			},
+		}
+		mockFS := &testutil.MockFS{
+			WrittenFiles: make(map[string][]byte),
+		}
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		result, err := cmd.Run(t.Context(), "feat/x", "/repo/main", OverlayOptions{
+			Target: "main",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.SourceBranch != "feat/x" {
+			t.Errorf("SourceBranch = %q, want %q", result.SourceBranch, "feat/x")
+		}
+		if result.TargetBranch != "main" {
+			t.Errorf("TargetBranch = %q, want %q", result.TargetBranch, "main")
+		}
+		if result.ModifiedFiles != 3 {
+			t.Errorf("ModifiedFiles = %d, want 3", result.ModifiedFiles)
+		}
+		if len(result.DeletedFiles) != 1 || result.DeletedFiles[0] != "old-file.txt" {
+			t.Errorf("DeletedFiles = %v, want [old-file.txt]", result.DeletedFiles)
+		}
+		if len(result.AddedFiles) != 1 || result.AddedFiles[0] != "new-file.go" {
+			t.Errorf("AddedFiles = %v, want [new-file.go]", result.AddedFiles)
+		}
+
+		// State file should be written
+		statePath := "/repo/main/.git/twig-overlay"
+		if _, ok := mockFS.WrittenFiles[statePath]; !ok {
+			t.Error("state file was not written")
+		}
+	})
+
+	t.Run("TargetHasChanges_Refuse", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "main-commit"},
+			},
+			HasChanges: true,
+		}
+		mockFS := &testutil.MockFS{}
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		_, err := cmd.Run(t.Context(), "feat/x", "/repo/main", OverlayOptions{
+			Target: "main",
+		})
+		if err == nil {
+			t.Fatal("expected error for dirty target")
+		}
+		if !strings.Contains(err.Error(), "uncommitted changes") {
+			t.Errorf("error = %q, want to contain 'uncommitted changes'", err.Error())
+		}
+	})
+
+	t.Run("TargetHasChanges_ForceProceeds", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "main-commit"},
+				{Path: "/repo/feat-x", Branch: "feat/x", HEAD: "feat-x-commit"},
+			},
+			HasChanges: true,
+			BranchHEADs: map[string]string{
+				"feat/x": "feat-x-commit",
+			},
+			DiffNameOnlyOutput: map[string]string{
+				"D:HEAD:feat-x-commit": "",
+				"A:HEAD:feat-x-commit": "",
+				":HEAD:feat-x-commit":  "file.go\n",
+			},
+		}
+		mockFS := &testutil.MockFS{
+			WrittenFiles: make(map[string][]byte),
+		}
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		_, err := cmd.Run(t.Context(), "feat/x", "/repo/main", OverlayOptions{
+			Target: "main",
+			Force:  true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error with --force: %v", err)
+		}
+	})
+
+	t.Run("OverlayAlreadyActive_Refuse", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "main-commit"},
+			},
+		}
+		mockFS := &testutil.MockFS{
+			ExistingPaths: []string{"/repo/main/.git/twig-overlay"},
+		}
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		_, err := cmd.Run(t.Context(), "feat/x", "/repo/main", OverlayOptions{
+			Target: "main",
+		})
+		if err == nil {
+			t.Fatal("expected error for active overlay")
+		}
+		if !strings.Contains(err.Error(), "overlay already active") {
+			t.Errorf("error = %q, want to contain 'overlay already active'", err.Error())
+		}
+	})
+
+	t.Run("SourceNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		// The default mock returns "default-<branch>" for unknown branches
+		// without error. We need a custom RunFunc for all commands.
+		mockGit := &testutil.MockGitExecutor{}
+		var worktreeListOutput = "worktree /repo/main\nHEAD main-commit\nbranch refs/heads/main\n\n"
+		mockGit.RunFunc = func(_ context.Context, args ...string) ([]byte, error) {
+			for len(args) >= 2 && args[0] == "-C" {
+				args = args[2:]
+			}
+			switch {
+			case len(args) >= 2 && args[0] == "rev-parse":
+				for _, a := range args {
+					if a == "--git-dir" {
+						return []byte("/repo/main/.git\n"), nil
+					}
+				}
+				if args[1] == "nonexistent" {
+					return nil, &testutil.MockExitError{Code: 128}
+				}
+				if args[1] == "HEAD" {
+					return []byte("main-commit\n"), nil
+				}
+				return []byte("some-commit\n"), nil
+			case len(args) >= 2 && args[0] == "worktree" && args[1] == "list":
+				return []byte(worktreeListOutput), nil
+			case len(args) >= 2 && args[0] == "status":
+				return []byte{}, nil
+			}
+			return nil, nil
+		}
+
+		mockFS := &testutil.MockFS{}
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		_, err := cmd.Run(t.Context(), "nonexistent", "/repo/main", OverlayOptions{
+			Target: "main",
+		})
+		if err == nil {
+			t.Fatal("expected error for nonexistent source")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("error = %q, want to contain 'not found'", err.Error())
+		}
+	})
+
+	t.Run("SourceEqualsTarget_SameCommit", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "same-commit-abc"},
+			},
+			BranchHEADs: map[string]string{
+				"feat/x": "same-commit-abc",
+			},
+		}
+		mockFS := &testutil.MockFS{}
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		_, err := cmd.Run(t.Context(), "feat/x", "/repo/main", OverlayOptions{
+			Target: "main",
+		})
+		if err == nil {
+			t.Fatal("expected error for same commit")
+		}
+		if !strings.Contains(err.Error(), "same commit") {
+			t.Errorf("error = %q, want to contain 'same commit'", err.Error())
+		}
+	})
+
+	t.Run("CheckMode_NoStateFile", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "main-commit"},
+				{Path: "/repo/feat-x", Branch: "feat/x", HEAD: "feat-x-commit"},
+			},
+			BranchHEADs: map[string]string{
+				"feat/x": "feat-x-commit",
+			},
+			DiffNameOnlyOutput: map[string]string{
+				"D:HEAD:feat-x-commit": "",
+				"A:HEAD:feat-x-commit": "new.go\n",
+				":HEAD:feat-x-commit":  "file.go\nnew.go\n",
+			},
+		}
+		mockFS := &testutil.MockFS{
+			WrittenFiles: make(map[string][]byte),
+		}
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		result, err := cmd.Run(t.Context(), "feat/x", "/repo/main", OverlayOptions{
+			Target: "main",
+			Check:  true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Check {
+			t.Error("Check should be true")
+		}
+		// State file should NOT be written in check mode
+		if _, ok := mockFS.WrittenFiles["/repo/main/.git/twig-overlay"]; ok {
+			t.Error("state file should not be written in check mode")
+		}
+	})
+}
+
+func TestOverlayCommand_Restore(t *testing.T) {
+	t.Parallel()
+
+	t.Run("BasicRestore", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "main-commit"},
+			},
+		}
+		mockFS := &testutil.MockFS{
+			ReadFileResults: map[string][]byte{
+				"/repo/main/.git/twig-overlay": []byte(`{
+					"source_branch": "feat/x",
+					"source_commit": "feat-x-commit",
+					"target_branch": "main",
+					"target_commit": "main-commit",
+					"added_files": ["new-file.go"]
+				}`),
+			},
+			WrittenFiles: make(map[string][]byte),
+		}
+
+		// Track removes
+		var removedFiles []string
+		mockFS.RemoveFunc = func(name string) error {
+			removedFiles = append(removedFiles, name)
+			return nil
+		}
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		result, err := cmd.Run(t.Context(), "", "/repo/main", OverlayOptions{
+			Restore: true,
+			Target:  "main",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Restored {
+			t.Error("Restored should be true")
+		}
+		if result.SourceBranch != "feat/x" {
+			t.Errorf("SourceBranch = %q, want %q", result.SourceBranch, "feat/x")
+		}
+
+		// Check that added files were removed
+		foundAddedFile := false
+		foundStateFile := false
+		for _, f := range removedFiles {
+			if f == "/repo/main/new-file.go" {
+				foundAddedFile = true
+			}
+			if f == "/repo/main/.git/twig-overlay" {
+				foundStateFile = true
+			}
+		}
+		if !foundAddedFile {
+			t.Error("added file should have been removed")
+		}
+		if !foundStateFile {
+			t.Error("state file should have been removed")
+		}
+	})
+
+	t.Run("NoOverlayActive", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "main-commit"},
+			},
+		}
+		mockFS := &testutil.MockFS{}
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		_, err := cmd.Run(t.Context(), "", "/repo/main", OverlayOptions{
+			Restore: true,
+			Target:  "main",
+		})
+		if err == nil {
+			t.Fatal("expected error for no active overlay")
+		}
+		if !strings.Contains(err.Error(), "no overlay active") {
+			t.Errorf("error = %q, want to contain 'no overlay active'", err.Error())
+		}
+	})
+
+	t.Run("HEADMoved_Refuse", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "new-head-commit"},
+			},
+		}
+		mockFS := &testutil.MockFS{
+			ReadFileResults: map[string][]byte{
+				"/repo/main/.git/twig-overlay": []byte(`{
+					"source_branch": "feat/x",
+					"source_commit": "feat-x-commit",
+					"target_branch": "main",
+					"target_commit": "original-head-commit"
+				}`),
+			},
+		}
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		_, err := cmd.Run(t.Context(), "", "/repo/main", OverlayOptions{
+			Restore: true,
+			Target:  "main",
+		})
+		if err == nil {
+			t.Fatal("expected error for HEAD movement")
+		}
+		if !strings.Contains(err.Error(), "HEAD has moved") {
+			t.Errorf("error = %q, want to contain 'HEAD has moved'", err.Error())
+		}
+	})
+
+	t.Run("HEADMoved_ForceProceeds", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "new-head-commit"},
+			},
+		}
+		mockFS := &testutil.MockFS{
+			ReadFileResults: map[string][]byte{
+				"/repo/main/.git/twig-overlay": []byte(`{
+					"source_branch": "feat/x",
+					"source_commit": "feat-x-commit",
+					"target_branch": "main",
+					"target_commit": "original-head-commit",
+					"added_files": []
+				}`),
+			},
+		}
+		mockFS.RemoveFunc = func(name string) error { return nil }
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		_, err := cmd.Run(t.Context(), "", "/repo/main", OverlayOptions{
+			Restore: true,
+			Target:  "main",
+			Force:   true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error with --force: %v", err)
+		}
+	})
+
+	t.Run("CheckMode_NoStateFileDeleted", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "main-commit"},
+			},
+		}
+		mockFS := &testutil.MockFS{
+			ReadFileResults: map[string][]byte{
+				"/repo/main/.git/twig-overlay": []byte(`{
+					"source_branch": "feat/x",
+					"source_commit": "feat-x-commit",
+					"target_branch": "main",
+					"target_commit": "main-commit",
+					"added_files": ["new.go"]
+				}`),
+			},
+		}
+		var removeCalled bool
+		mockFS.RemoveFunc = func(name string) error {
+			removeCalled = true
+			return nil
+		}
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		result, err := cmd.Run(t.Context(), "", "/repo/main", OverlayOptions{
+			Restore: true,
+			Target:  "main",
+			Check:   true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !result.Restored || !result.Check {
+			t.Error("expected Restored=true, Check=true")
+		}
+		if removeCalled {
+			t.Error("Remove should not be called in check mode")
+		}
+	})
+}
+
+func TestOverlayResult_Format(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		result     OverlayResult
+		opts       OverlayFormatOptions
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			name: "apply_default",
+			result: OverlayResult{
+				TargetBranch:  "main",
+				SourceBranch:  "feat/x",
+				ModifiedFiles: 42,
+				DeletedFiles:  []string{"a.txt", "b.txt"},
+				AddedFiles:    []string{"c.go"},
+			},
+			opts:       OverlayFormatOptions{},
+			wantStdout: "Overlaid main with feat/x (42 files changed, 2 deleted, 1 added)\n",
+			wantStderr: "warning: do not commit in the overlaid worktree.\n         Use 'twig overlay --restore' when done.\n",
+		},
+		{
+			name: "apply_no_deletes_no_adds",
+			result: OverlayResult{
+				TargetBranch:  "main",
+				SourceBranch:  "feat/x",
+				ModifiedFiles: 5,
+			},
+			opts:       OverlayFormatOptions{},
+			wantStdout: "Overlaid main with feat/x (5 files changed)\n",
+			wantStderr: "warning: do not commit in the overlaid worktree.\n         Use 'twig overlay --restore' when done.\n",
+		},
+		{
+			name: "restore_default",
+			result: OverlayResult{
+				Restored:     true,
+				TargetBranch: "main",
+				SourceBranch: "feat/x",
+			},
+			opts:       OverlayFormatOptions{},
+			wantStdout: "Restored main (removed overlay from feat/x)\n",
+			wantStderr: "",
+		},
+		{
+			name: "check_apply",
+			result: OverlayResult{
+				Check:         true,
+				TargetBranch:  "main",
+				SourceBranch:  "feat/x",
+				ModifiedFiles: 10,
+				DeletedFiles:  []string{"old.txt"},
+				AddedFiles:    []string{"new.go"},
+			},
+			opts: OverlayFormatOptions{},
+			wantStdout: "Would overlay main with feat/x:\n" +
+				"  10 file(s) would change\n" +
+				"  1 file(s) would be deleted\n" +
+				"  1 file(s) would be added\n",
+		},
+		{
+			name: "check_restore",
+			result: OverlayResult{
+				Check:        true,
+				Restored:     true,
+				TargetBranch: "main",
+				SourceBranch: "feat/x",
+				AddedFiles:   []string{"new.go"},
+			},
+			opts: OverlayFormatOptions{},
+			wantStdout: "Would restore main (remove overlay from feat/x)\n" +
+				"  1 overlay-added file(s) would be removed\n",
+		},
+		{
+			name: "quiet_suppresses_output",
+			result: OverlayResult{
+				TargetBranch:  "main",
+				SourceBranch:  "feat/x",
+				ModifiedFiles: 5,
+			},
+			opts:       OverlayFormatOptions{Quiet: true},
+			wantStdout: "",
+			wantStderr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			formatted := tt.result.Format(tt.opts)
+			if formatted.Stdout != tt.wantStdout {
+				t.Errorf("Stdout:\ngot:  %q\nwant: %q", formatted.Stdout, tt.wantStdout)
+			}
+			if formatted.Stderr != tt.wantStderr {
+				t.Errorf("Stderr:\ngot:  %q\nwant: %q", formatted.Stderr, tt.wantStderr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Add `twig overlay` command that overlays file contents from a source branch onto a target worktree without changing the checked-out branch.

## Why

When testing changes from a feature branch in the context of another worktree, git does not allow the same branch to be checked out in multiple worktrees. A file-level overlay mechanism enables this without branch switching.

## What

### New command: `twig overlay`

```bash
twig overlay <source-branch> [flags]   # Apply overlay
twig overlay --restore [flags]          # Restore original state
```

**Flags:**
- `--restore`: Restore target worktree to original state
- `--target <branch>`: Target worktree (default: current)
- `--check`: Dry-run mode
- `--force` / `-f`: Proceed even if target is dirty or HEAD has moved
- `--verbose` / `-v`: Verbose output
- `--quiet` / `-q`: Suppress output

**Safety features:**
- Refuses if target has uncommitted changes (bypass with `--force`)
- Refuses if overlay is already active (must restore first, even with `--force`)
- Warns not to commit in overlaid worktree
- Detects HEAD movement on restore (commits made during overlay)
- Preserves user-created files on restore (targeted delete, no `git clean`)

## Type of Change

- [x] Feature
- [x] Documentation
- [x] Test

## How to Test

```bash
# Unit tests
go test ./...

# Integration tests
go test -tags=integration ./...

# Manual test
twig overlay <feature-branch> --target main
twig overlay --restore --target main
```