### PR TITLE
feat: add post-create hooks for worktree initialization

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "twig",
       "description": "Claude Code plugin for twig - simplifies git worktree workflows",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "category": "productivity",
       "keywords": ["git", "worktree", "branch", "cli", "twig"],
       "source": "./external/claude-code/plugins/twig"

--- a/add.go
+++ b/add.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -77,6 +78,13 @@ type SubmoduleInitResult struct {
 	NoReferenceSubmodules []string // submodules that couldn't use reference
 }
 
+// HookResult holds the result of a single hook execution.
+type HookResult struct {
+	Command string
+	Output  []byte
+	Err     error
+}
+
 // AddResult holds the result of an add operation.
 type AddResult struct {
 	Branch         string
@@ -86,6 +94,7 @@ type AddResult struct {
 	ChangesSynced  bool
 	ChangesCarried bool
 	SubmoduleInit  SubmoduleInitResult
+	HookResults    []HookResult
 }
 
 // AddFormatOptions configures add output formatting.
@@ -130,6 +139,19 @@ func (r AddResult) formatDefault(opts AddFormatOptions) FormatResult {
 		fmt.Fprintf(&stderr, "warning: submodule %s: reference not available, initialize in main worktree first\n", sm)
 	}
 
+	// Output hook results (single pass: warnings to stderr, count successes)
+	var hookRanCount int
+	for _, h := range r.HookResults {
+		if h.Err != nil {
+			fmt.Fprintf(&stderr, "warning: hook %q failed: %v\n", h.Command, h.Err)
+			if len(h.Output) > 0 {
+				stderr.Write(h.Output)
+			}
+		} else {
+			hookRanCount++
+		}
+	}
+
 	if opts.Verbose {
 		if len(r.GitOutput) > 0 {
 			stdout.Write(r.GitOutput)
@@ -149,6 +171,14 @@ func (r AddResult) formatDefault(opts AddFormatOptions) FormatResult {
 		if r.SubmoduleInit.Attempted && r.SubmoduleInit.Count > 0 {
 			fmt.Fprintf(&stdout, "Initialized %d submodule(s)\n", r.SubmoduleInit.Count)
 		}
+		for _, h := range r.HookResults {
+			if h.Err == nil {
+				fmt.Fprintf(&stdout, "Ran hook: %s\n", h.Command)
+				if len(h.Output) > 0 {
+					stdout.Write(h.Output)
+				}
+			}
+		}
 	}
 
 	var syncInfo string
@@ -162,7 +192,12 @@ func (r AddResult) formatDefault(opts AddFormatOptions) FormatResult {
 	if r.SubmoduleInit.Attempted && r.SubmoduleInit.Count > 0 {
 		submoduleInfo = fmt.Sprintf(", %d submodules", r.SubmoduleInit.Count)
 	}
-	fmt.Fprintf(&stdout, "twig add: %s (%d symlinks%s%s)\n", r.Branch, createdCount, syncInfo, submoduleInfo)
+
+	var hookInfo string
+	if hookRanCount > 0 {
+		hookInfo = fmt.Sprintf(", %d hooks ran", hookRanCount)
+	}
+	fmt.Fprintf(&stdout, "twig add: %s (%d symlinks%s%s%s)\n", r.Branch, createdCount, syncInfo, submoduleInfo, hookInfo)
 
 	return FormatResult{Stdout: stdout.String(), Stderr: stderr.String()}
 }
@@ -297,7 +332,33 @@ func (c *AddCommand) Run(ctx context.Context, name string) (AddResult, error) {
 	}
 	result.Symlinks = symlinks
 
+	// Run post-create hooks
+	if len(c.Config.Hooks) > 0 {
+		result.HookResults = c.runHooks(ctx, wtPath)
+	}
+
 	return result, nil
+}
+
+func (c *AddCommand) runHooks(ctx context.Context, dir string) []HookResult {
+	var results []HookResult
+	for _, hook := range c.Config.Hooks {
+		c.Log.DebugContext(ctx, "running hook", "command", hook, "dir", dir)
+		cmd := exec.CommandContext(ctx, "sh", "-c", hook)
+		cmd.Dir = dir
+		output, err := cmd.CombinedOutput()
+		results = append(results, HookResult{
+			Command: hook,
+			Output:  output,
+			Err:     err,
+		})
+		if err != nil {
+			c.Log.WarnContext(ctx, "hook failed", "command", hook, "error", err)
+			break
+		}
+		c.Log.DebugContext(ctx, "hook completed", "command", hook)
+	}
+	return results
 }
 
 func (c *AddCommand) createWorktree(ctx context.Context, branch, path string) ([]byte, error) {

--- a/add_integration_test.go
+++ b/add_integration_test.go
@@ -1695,6 +1695,216 @@ worktree_destination_base_dir = %q
 	})
 }
 
+func TestAddCommand_Hooks_Integration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HooksExecuteInNewWorktree", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		// Setup twig config with hooks
+		twigDir := filepath.Join(mainDir, ".twig")
+		settings := fmt.Sprintf(`worktree_destination_base_dir = %q
+hooks = ["touch .hook-executed"]
+`, repoDir)
+		if err := os.WriteFile(filepath.Join(twigDir, "settings.toml"), []byte(settings), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LoadConfig(mainDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := NewDefaultAddCommand(result.Config, NewNopLogger(), AddOptions{})
+
+		addResult, err := cmd.Run(t.Context(), "feature/hooks-test")
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		// Verify worktree was created
+		wtPath := filepath.Join(repoDir, "feature", "hooks-test")
+		if _, err := os.Stat(wtPath); os.IsNotExist(err) {
+			t.Errorf("worktree directory does not exist: %s", wtPath)
+		}
+
+		// Verify hook was executed (file created in new worktree)
+		hookFile := filepath.Join(wtPath, ".hook-executed")
+		if _, err := os.Stat(hookFile); os.IsNotExist(err) {
+			t.Errorf("hook file does not exist: %s", hookFile)
+		}
+
+		// Verify result
+		if len(addResult.HookResults) != 1 {
+			t.Fatalf("HookResults length = %d, want 1", len(addResult.HookResults))
+		}
+		if addResult.HookResults[0].Err != nil {
+			t.Errorf("hook error = %v, want nil", addResult.HookResults[0].Err)
+		}
+		if addResult.HookResults[0].Command != "touch .hook-executed" {
+			t.Errorf("hook command = %q, want %q", addResult.HookResults[0].Command, "touch .hook-executed")
+		}
+	})
+
+	t.Run("HookFailureIsWarning", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		// Setup twig config with failing hook
+		twigDir := filepath.Join(mainDir, ".twig")
+		settings := fmt.Sprintf(`worktree_destination_base_dir = %q
+hooks = ["exit 1"]
+`, repoDir)
+		if err := os.WriteFile(filepath.Join(twigDir, "settings.toml"), []byte(settings), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LoadConfig(mainDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := NewDefaultAddCommand(result.Config, NewNopLogger(), AddOptions{})
+
+		addResult, err := cmd.Run(t.Context(), "feature/hooks-fail")
+		// Worktree creation should succeed even with hook failure
+		if err != nil {
+			t.Fatalf("Run failed: %v (should succeed despite hook failure)", err)
+		}
+
+		// Verify worktree was created
+		wtPath := filepath.Join(repoDir, "feature", "hooks-fail")
+		if _, err := os.Stat(wtPath); os.IsNotExist(err) {
+			t.Errorf("worktree directory does not exist: %s", wtPath)
+		}
+
+		// Verify hook result captures error
+		if len(addResult.HookResults) != 1 {
+			t.Fatalf("HookResults length = %d, want 1", len(addResult.HookResults))
+		}
+		if addResult.HookResults[0].Err == nil {
+			t.Error("hook error should not be nil")
+		}
+	})
+
+	t.Run("HookFailureStopsRemaining", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		// Setup twig config: first hook fails, second should not run
+		twigDir := filepath.Join(mainDir, ".twig")
+		settings := fmt.Sprintf(`worktree_destination_base_dir = %q
+hooks = ["exit 1", "touch .should-not-exist"]
+`, repoDir)
+		if err := os.WriteFile(filepath.Join(twigDir, "settings.toml"), []byte(settings), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LoadConfig(mainDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := NewDefaultAddCommand(result.Config, NewNopLogger(), AddOptions{})
+
+		addResult, err := cmd.Run(t.Context(), "feature/hooks-stop")
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		wtPath := filepath.Join(repoDir, "feature", "hooks-stop")
+
+		// Verify second hook did not run
+		shouldNotExist := filepath.Join(wtPath, ".should-not-exist")
+		if _, err := os.Stat(shouldNotExist); !os.IsNotExist(err) {
+			t.Errorf("second hook should not have run: %s exists", shouldNotExist)
+		}
+
+		// Only first hook result should be present
+		if len(addResult.HookResults) != 1 {
+			t.Errorf("HookResults length = %d, want 1", len(addResult.HookResults))
+		}
+	})
+
+	t.Run("MultipleHooksRunInOrder", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		// Setup twig config with multiple hooks
+		twigDir := filepath.Join(mainDir, ".twig")
+		settings := fmt.Sprintf(`worktree_destination_base_dir = %q
+hooks = ["echo first > order.txt", "echo second >> order.txt"]
+`, repoDir)
+		if err := os.WriteFile(filepath.Join(twigDir, "settings.toml"), []byte(settings), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LoadConfig(mainDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := NewDefaultAddCommand(result.Config, NewNopLogger(), AddOptions{})
+
+		addResult, err := cmd.Run(t.Context(), "feature/hooks-order")
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		wtPath := filepath.Join(repoDir, "feature", "hooks-order")
+
+		// Verify hooks ran in order
+		orderFile := filepath.Join(wtPath, "order.txt")
+		content, err := os.ReadFile(orderFile)
+		if err != nil {
+			t.Fatalf("failed to read order file: %v", err)
+		}
+		want := "first\nsecond\n"
+		if string(content) != want {
+			t.Errorf("order file content = %q, want %q", string(content), want)
+		}
+
+		if len(addResult.HookResults) != 2 {
+			t.Errorf("HookResults length = %d, want 2", len(addResult.HookResults))
+		}
+	})
+
+	t.Run("EmptyHooksNoExecution", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		// Setup twig config without hooks
+		twigDir := filepath.Join(mainDir, ".twig")
+		settings := fmt.Sprintf(`worktree_destination_base_dir = %q
+`, repoDir)
+		if err := os.WriteFile(filepath.Join(twigDir, "settings.toml"), []byte(settings), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LoadConfig(mainDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := NewDefaultAddCommand(result.Config, NewNopLogger(), AddOptions{})
+
+		addResult, err := cmd.Run(t.Context(), "feature/no-hooks")
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		if len(addResult.HookResults) != 0 {
+			t.Errorf("HookResults length = %d, want 0", len(addResult.HookResults))
+		}
+	})
+}
+
 // TestAddCommand_Submodules_Integration tests submodule initialization.
 // Not parallel: uses t.Setenv for file:// protocol in local submodule URLs.
 func TestAddCommand_Submodules_Integration(t *testing.T) {

--- a/add_test.go
+++ b/add_test.go
@@ -1144,3 +1144,114 @@ func TestCreateSymlinks_RelativePath(t *testing.T) {
 		})
 	}
 }
+
+func TestAddResult_Format_Hooks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default_output_with_hooks", func(t *testing.T) {
+		t.Parallel()
+
+		result := AddResult{
+			Branch:       "feature/test",
+			WorktreePath: "/worktrees/feature/test",
+			Symlinks:     []SymlinkResult{},
+			HookResults: []HookResult{
+				{Command: "npm install"},
+				{Command: "direnv allow"},
+			},
+		}
+
+		got := result.Format(AddFormatOptions{})
+		want := "twig add: feature/test (0 symlinks, 2 hooks ran)\n"
+
+		if got.Stdout != want {
+			t.Errorf("Stdout = %q, want %q", got.Stdout, want)
+		}
+	})
+
+	t.Run("hook_failure_warning", func(t *testing.T) {
+		t.Parallel()
+
+		result := AddResult{
+			Branch:       "feature/test",
+			WorktreePath: "/worktrees/feature/test",
+			Symlinks:     []SymlinkResult{},
+			HookResults: []HookResult{
+				{Command: "npm install", Err: errors.New("exit status 1"), Output: []byte("npm ERR!\n")},
+			},
+		}
+
+		got := result.Format(AddFormatOptions{})
+
+		if !strings.Contains(got.Stderr, "warning:") {
+			t.Errorf("Stderr = %q, should contain 'warning:'", got.Stderr)
+		}
+		if !strings.Contains(got.Stderr, "npm install") {
+			t.Errorf("Stderr = %q, should contain hook command", got.Stderr)
+		}
+		if !strings.Contains(got.Stderr, "npm ERR!") {
+			t.Errorf("Stderr = %q, should contain hook output", got.Stderr)
+		}
+	})
+
+	t.Run("verbose_output_with_hooks", func(t *testing.T) {
+		t.Parallel()
+
+		result := AddResult{
+			Branch:       "feature/test",
+			WorktreePath: "/worktrees/feature/test",
+			Symlinks:     []SymlinkResult{},
+			HookResults: []HookResult{
+				{Command: "npm install", Output: []byte("added 100 packages\n")},
+			},
+		}
+
+		got := result.Format(AddFormatOptions{Verbose: true})
+
+		if !strings.Contains(got.Stdout, "Ran hook: npm install") {
+			t.Errorf("Stdout = %q, should contain 'Ran hook: npm install'", got.Stdout)
+		}
+		if !strings.Contains(got.Stdout, "added 100 packages") {
+			t.Errorf("Stdout = %q, should contain hook output", got.Stdout)
+		}
+	})
+
+	t.Run("no_hook_info_when_empty", func(t *testing.T) {
+		t.Parallel()
+
+		result := AddResult{
+			Branch:       "feature/test",
+			WorktreePath: "/worktrees/feature/test",
+			Symlinks:     []SymlinkResult{},
+			HookResults:  []HookResult{},
+		}
+
+		got := result.Format(AddFormatOptions{})
+		want := "twig add: feature/test (0 symlinks)\n"
+
+		if got.Stdout != want {
+			t.Errorf("Stdout = %q, want %q", got.Stdout, want)
+		}
+	})
+
+	t.Run("failed_hooks_not_counted_in_summary", func(t *testing.T) {
+		t.Parallel()
+
+		result := AddResult{
+			Branch:       "feature/test",
+			WorktreePath: "/worktrees/feature/test",
+			Symlinks:     []SymlinkResult{},
+			HookResults: []HookResult{
+				{Command: "npm install"},
+				{Command: "bad-command", Err: errors.New("exit status 1")},
+			},
+		}
+
+		got := result.Format(AddFormatOptions{})
+		want := "twig add: feature/test (0 symlinks, 1 hooks ran)\n"
+
+		if got.Stdout != want {
+			t.Errorf("Stdout = %q, want %q", got.Stdout, want)
+		}
+	})
+}

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	InitSubmodules      *bool    `toml:"init_submodules"`     // nil=unset, true=enable, false=disable
 	SubmoduleReference  *bool    `toml:"submodule_reference"` // nil=unset, true=enable, false=disable
 	CleanStale          *bool    `toml:"clean_stale"`         // nil=unset, true=enable, false=disable
+	Hooks               []string `toml:"hooks"`
 }
 
 // ShouldInitSubmodules returns whether submodule initialization is enabled.
@@ -194,6 +195,15 @@ func LoadConfig(dir string, opts ...LoadConfigOption) (*LoadConfigResult, error)
 		cleanStale = localCfg.CleanStale
 	}
 
+	// hooks: local overrides project
+	var hooks []string
+	if projCfg != nil && len(projCfg.Hooks) > 0 {
+		hooks = projCfg.Hooks
+	}
+	if localCfg != nil && len(localCfg.Hooks) > 0 {
+		hooks = localCfg.Hooks
+	}
+
 	return &LoadConfigResult{
 		Config: &Config{
 			Symlinks:            symlinks,
@@ -204,6 +214,7 @@ func LoadConfig(dir string, opts ...LoadConfigOption) (*LoadConfigResult, error)
 			InitSubmodules:      initSubmodules,
 			SubmoduleReference:  submoduleReference,
 			CleanStale:          cleanStale,
+			Hooks:               hooks,
 		},
 		Warnings: warnings,
 	}, nil

--- a/config_test.go
+++ b/config_test.go
@@ -706,3 +706,120 @@ func TestLoadConfig_CleanStale(t *testing.T) {
 		}
 	})
 }
+
+func TestLoadConfig_Hooks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ProjectOnly", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		twigDir := filepath.Join(tmpDir, configDir)
+		if err := os.MkdirAll(twigDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		projectSettings := `hooks = ["npm install", "direnv allow"]
+`
+		if err := os.WriteFile(filepath.Join(twigDir, configFileName), []byte(projectSettings), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LoadConfig(tmpDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := []string{"npm install", "direnv allow"}
+		if !reflect.DeepEqual(result.Config.Hooks, expected) {
+			t.Errorf("Hooks = %v, want %v", result.Config.Hooks, expected)
+		}
+	})
+
+	t.Run("LocalOverridesProject", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		twigDir := filepath.Join(tmpDir, configDir)
+		if err := os.MkdirAll(twigDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		projectSettings := `hooks = ["npm install", "direnv allow"]
+`
+		if err := os.WriteFile(filepath.Join(twigDir, configFileName), []byte(projectSettings), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		localSettings := `hooks = ["yarn install"]
+`
+		if err := os.WriteFile(filepath.Join(twigDir, localConfigFileName), []byte(localSettings), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LoadConfig(tmpDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := []string{"yarn install"}
+		if !reflect.DeepEqual(result.Config.Hooks, expected) {
+			t.Errorf("Hooks = %v, want %v", result.Config.Hooks, expected)
+		}
+	})
+
+	t.Run("EmptyLocalDoesNotOverride", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		twigDir := filepath.Join(tmpDir, configDir)
+		if err := os.MkdirAll(twigDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		projectSettings := `hooks = ["npm install"]
+`
+		if err := os.WriteFile(filepath.Join(twigDir, configFileName), []byte(projectSettings), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		localSettings := `hooks = []
+`
+		if err := os.WriteFile(filepath.Join(twigDir, localConfigFileName), []byte(localSettings), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LoadConfig(tmpDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := []string{"npm install"}
+		if !reflect.DeepEqual(result.Config.Hooks, expected) {
+			t.Errorf("Hooks = %v, want %v", result.Config.Hooks, expected)
+		}
+	})
+
+	t.Run("NilWhenUnset", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		twigDir := filepath.Join(tmpDir, configDir)
+		if err := os.MkdirAll(twigDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := os.WriteFile(filepath.Join(twigDir, configFileName), []byte(""), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := LoadConfig(tmpDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if result.Config.Hooks != nil {
+			t.Errorf("Hooks = %v, want nil", result.Config.Hooks)
+		}
+	})
+}

--- a/docs/reference/commands/add.md
+++ b/docs/reference/commands/add.md
@@ -239,6 +239,43 @@ Priority:
 2. Config `submodule_reference`
 3. Default: disabled
 
+### Post-Create Hooks
+
+Commands configured in `hooks` are executed after worktree
+creation and symlink setup:
+
+```toml
+# .twig/settings.toml
+hooks = ["npm install", "direnv allow"]
+```
+
+Execution details:
+
+- Each command runs via `sh -c` in the new worktree directory
+- Commands run in the order listed
+- stdout/stderr are forwarded to stderr
+- If a hook fails, remaining hooks are skipped
+- Hook failure does not fail the `twig add` command
+  (a warning is displayed)
+
+```bash
+# Hooks run automatically after worktree creation
+twig add feat/new
+# twig add: feat/new (2 symlinks, 2 hooks ran)
+```
+
+With `--verbose`, individual hook execution is shown:
+
+```bash
+twig add feat/new -v
+# Ran hook: npm install
+# added 100 packages
+# Ran hook: direnv allow
+# twig add: feat/new (2 symlinks, 2 hooks ran)
+```
+
+See [Configuration](../configuration.md#hooks) for merge rules.
+
 ### Default Source Configuration
 
 The default source branch can be configured in `.twig/settings.toml`:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -106,6 +106,24 @@ The CLI flag `--stale` forces enable regardless of this setting.
 
 See [clean subcommand](commands/clean.md#stale-option) for details.
 
+### hooks
+
+Commands to run after worktree creation.
+
+```toml
+hooks = ["npm install", "direnv allow"]
+```
+
+Default: `[]` (no hooks)
+
+Each command is executed via `sh -c` in the new worktree
+directory, in order. If a hook fails, remaining hooks are
+skipped and a warning is displayed, but the worktree creation
+itself succeeds.
+
+See [add subcommand](commands/add.md#post-create-hooks)
+for details.
+
 ## Merge Rules
 
 When both files exist, settings are merged:
@@ -119,6 +137,7 @@ When both files exist, settings are merged:
 | `init_submodules`               | Local overrides project | `false`                        |
 | `submodule_reference`           | Local overrides project | `false`                        |
 | `clean_stale`                   | Local overrides project | `false`                        |
+| `hooks`                         | Local overrides project | `[]`                           |
 
 ## symlinks vs extra_symlinks
 
@@ -158,6 +177,7 @@ symlinks = [".envrc", ".tool-versions", "config/**"]
 init_submodules = true
 submodule_reference = true
 clean_stale = true
+hooks = ["npm install", "direnv allow"]
 ```
 
 ```toml

--- a/external/claude-code/plugins/twig/.claude-plugin/plugin.json
+++ b/external/claude-code/plugins/twig/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "twig",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Claude Code plugin for twig - simplifies git worktree workflows",
   "author": {
     "name": "708u"

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/commands/add.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/commands/add.md
@@ -239,6 +239,43 @@ Priority:
 2. Config `submodule_reference`
 3. Default: disabled
 
+### Post-Create Hooks
+
+Commands configured in `hooks` are executed after worktree
+creation and symlink setup:
+
+```toml
+# .twig/settings.toml
+hooks = ["npm install", "direnv allow"]
+```
+
+Execution details:
+
+- Each command runs via `sh -c` in the new worktree directory
+- Commands run in the order listed
+- stdout/stderr are forwarded to stderr
+- If a hook fails, remaining hooks are skipped
+- Hook failure does not fail the `twig add` command
+  (a warning is displayed)
+
+```bash
+# Hooks run automatically after worktree creation
+twig add feat/new
+# twig add: feat/new (2 symlinks, 2 hooks ran)
+```
+
+With `--verbose`, individual hook execution is shown:
+
+```bash
+twig add feat/new -v
+# Ran hook: npm install
+# added 100 packages
+# Ran hook: direnv allow
+# twig add: feat/new (2 symlinks, 2 hooks ran)
+```
+
+See [Configuration](../configuration.md#hooks) for merge rules.
+
 ### Default Source Configuration
 
 The default source branch can be configured in `.twig/settings.toml`:

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/configuration.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/configuration.md
@@ -106,6 +106,24 @@ The CLI flag `--stale` forces enable regardless of this setting.
 
 See [clean subcommand](commands/clean.md#stale-option) for details.
 
+### hooks
+
+Commands to run after worktree creation.
+
+```toml
+hooks = ["npm install", "direnv allow"]
+```
+
+Default: `[]` (no hooks)
+
+Each command is executed via `sh -c` in the new worktree
+directory, in order. If a hook fails, remaining hooks are
+skipped and a warning is displayed, but the worktree creation
+itself succeeds.
+
+See [add subcommand](commands/add.md#post-create-hooks)
+for details.
+
 ## Merge Rules
 
 When both files exist, settings are merged:
@@ -119,6 +137,7 @@ When both files exist, settings are merged:
 | `init_submodules`               | Local overrides project | `false`                        |
 | `submodule_reference`           | Local overrides project | `false`                        |
 | `clean_stale`                   | Local overrides project | `false`                        |
+| `hooks`                         | Local overrides project | `[]`                           |
 
 ## symlinks vs extra_symlinks
 
@@ -158,6 +177,7 @@ symlinks = [".envrc", ".tool-versions", "config/**"]
 init_submodules = true
 submodule_reference = true
 clean_stale = true
+hooks = ["npm install", "direnv allow"]
 ```
 
 ```toml

--- a/init.go
+++ b/init.go
@@ -31,6 +31,9 @@ symlinks = []
 
 # Always enable --stale for clean command (default: false)
 # clean_stale = true
+
+# Commands to run after worktree creation (run in new worktree directory)
+# hooks = ["npm install", "direnv allow"]
 `
 
 // InitCommand initializes twig configuration in a directory.


### PR DESCRIPTION
## Overview

Add `hooks` configuration field to run arbitrary commands after worktree creation.

## Why

twig automates worktree creation with symlinks and submodule init, but lacks support for dynamic initialization like dependency installation (`npm install`) or environment setup (`direnv allow`). While shell wrappers can achieve this, embedding hooks in TOML config provides portability and shareability across team members.

## What

- Add `hooks` field to `Config` struct (`[]string`, TOML)
- Merge rule: local overrides project (same as `symlinks`)
- Execute hooks via `sh -c` in new worktree directory after symlink setup
- Stop on first failure, remaining hooks are skipped
- Hook failure is a warning (does not fail `twig add`)
- Summary line includes hook count (e.g., `2 hooks ran`)
- Verbose mode shows per-hook execution and output
- Add `hooks` comment example to `twig init` template
- Update docs for configuration and add subcommand
- Bump plugin version to 0.12.0

## Type of Change

- [x] Feature
- [x] Documentation
- [x] Test

## How to Test

```bash
# Unit tests
go test ./... -run "TestLoadConfig_Hooks|TestAddResult_Format_Hooks"

# Integration tests
go test -tags=integration ./... -run "TestAddCommand_Hooks_Integration"

# Manual test
echo 'hooks = ["touch .hook-ran"]' >> .twig/settings.toml
twig add feat/test-hooks
ls feat/test-hooks/.hook-ran  # should exist
```

## Checklist

- [x] Tests added/updated
- [x] Self-reviewed
