### PR TITLE
feat: add --dirty flag to overlay command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "twig",
       "description": "Claude Code plugin for twig - simplifies git worktree workflows",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "category": "productivity",
       "keywords": ["git", "worktree", "branch", "cli", "twig"],
       "source": "./external/claude-code/plugins/twig"

--- a/cmd/twig/main.go
+++ b/cmd/twig/main.go
@@ -980,7 +980,10 @@ Examples:
   twig overlay --restore --target main
 
   # Preview changes
-  twig overlay feat/x --target main --check`,
+  twig overlay feat/x --target main --check
+
+  # Include uncommitted changes from source worktree
+  twig overlay feat/x --target main --dirty`,
 		Args: cobra.MaximumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) >= 1 {
@@ -999,11 +1002,15 @@ Examples:
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			restore, _ := cmd.Flags().GetBool("restore")
+			dirty, _ := cmd.Flags().GetBool("dirty")
 			if restore && len(args) > 0 {
 				return fmt.Errorf("cannot specify source branch with --restore")
 			}
 			if !restore && len(args) == 0 {
 				return fmt.Errorf("source branch is required (or use --restore)")
+			}
+			if dirty && restore {
+				return fmt.Errorf("cannot use --dirty with --restore")
 			}
 			return nil
 		},
@@ -1014,6 +1021,7 @@ Examples:
 			check, _ := cmd.Flags().GetBool("check")
 			restore, _ := cmd.Flags().GetBool("restore")
 			force, _ := cmd.Flags().GetBool("force")
+			dirty, _ := cmd.Flags().GetBool("dirty")
 			target, _ := cmd.Flags().GetString("target")
 
 			idGen := twig.GenerateCommandID
@@ -1026,6 +1034,7 @@ Examples:
 				Restore: restore,
 				Check:   check,
 				Force:   force,
+				Dirty:   dirty,
 				Target:  target,
 			}
 
@@ -1062,6 +1071,7 @@ Examples:
 	overlayCmd.Flags().Bool("check", false, "Show what would be done (dry-run)")
 	overlayCmd.Flags().BoolP("force", "f", false, "Proceed even if target is dirty or HEAD has moved")
 	overlayCmd.Flags().BoolP("quiet", "q", false, "Suppress output")
+	overlayCmd.Flags().Bool("dirty", false, "Include uncommitted changes from source worktree")
 	overlayCmd.RegisterFlagCompletionFunc("target", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		dir, err := resolveCompletionDirectory(cmd)
 		if err != nil {

--- a/docs/reference/commands/overlay.md
+++ b/docs/reference/commands/overlay.md
@@ -21,6 +21,7 @@ twig overlay --restore [flags]          # Restore original state
 | `--target`  |       | Target worktree branch (default: current)       |
 | `--check`   |       | Show what would be done (dry-run)               |
 | `--force`   | `-f`  | Proceed even if target is dirty or HEAD moved   |
+| `--dirty`   |       | Include uncommitted changes from source worktree|
 | `--quiet`   | `-q`  | Suppress output                                 |
 | `--verbose` | `-v`  | Verbose output (use `-vv` for debug)            |
 
@@ -49,6 +50,39 @@ worktree.
 
 Files created by the user after overlay are preserved during restore.
 Only overlay-added files are removed.
+
+### Dirty Mode
+
+With `--dirty`, uncommitted changes from the source branch's worktree
+are applied on top of the committed overlay:
+
+1. Normal committed overlay is applied first
+2. Source worktree is located by branch name
+3. Each dirty file in the source worktree is copied to the target
+4. Deleted dirty files are removed from the target
+
+Requirements:
+
+- Source branch must have an existing worktree
+
+When source and target are at the same commit, `--dirty` allows the
+overlay to proceed (only dirty files are applied). Without dirty
+files, an error is returned.
+
+Untracked files in the source worktree are included and tracked
+for cleanup on restore.
+
+```bash
+# Overlay committed + uncommitted changes
+twig overlay feat/x --target main --dirty
+
+# Same commit, only dirty files
+twig overlay feat/x --dirty
+```
+
+Constraints:
+
+- Cannot be used with `--restore`
 
 ### Safety: Commit Prevention
 
@@ -136,6 +170,10 @@ With `--quiet`, no output is produced.
 | Submodules                    | Pointers updated, no init/deinit   |
 | Binary files                  | Handled by git checkout             |
 | Detached HEAD on target       | Works (recorded as "HEAD")          |
+| `--dirty` + same commit      | Only dirty files applied            |
+| `--dirty` without worktree   | Error (worktree required)           |
+| `--dirty` + `--restore`      | Error (mutually exclusive)          |
+| `--dirty` + no dirty files   | Error (same commit only)            |
 
 ## Examples
 
@@ -158,6 +196,12 @@ twig overlay --restore --target main
 
 # Force restore after accidental commit
 twig overlay --restore --target main --force
+
+# Include uncommitted changes from source worktree
+twig overlay feat/x --target main --dirty
+
+# Preview including dirty files
+twig overlay feat/x --target main --dirty --check
 ```
 
 ## Exit Code

--- a/external/claude-code/plugins/twig/.claude-plugin/plugin.json
+++ b/external/claude-code/plugins/twig/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "twig",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Claude Code plugin for twig - simplifies git worktree workflows",
   "author": {
     "name": "708u"

--- a/external/claude-code/plugins/twig/skills/twig-guide/SKILL.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/SKILL.md
@@ -9,6 +9,7 @@ description: |
   - Wants to carry or move uncommitted changes to a new branch
   - Wants to copy/sync changes between branches
   - Wants to temporarily apply another branch's files to a worktree
+  - Wants to test uncommitted/dirty changes from another worktree
   - Needs to isolate work in a separate directory
   - Asks about switching context without stashing
   - Wants to clean up old/merged branches and their worktrees
@@ -101,6 +102,19 @@ twig overlay feat/x --target main
 # ... test in main worktree ...
 twig overlay --restore --target main
 ```
+
+### Test uncommitted changes in another worktree
+
+Include dirty (uncommitted) files from the source worktree:
+
+```bash
+twig overlay feat/x --target main --dirty
+# ... test including uncommitted changes ...
+twig overlay --restore --target main
+```
+
+This also works when source and target are at the same commit
+(only dirty files are applied).
 
 ### Force remove a worktree
 

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/commands/overlay.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/commands/overlay.md
@@ -21,6 +21,7 @@ twig overlay --restore [flags]          # Restore original state
 | `--target`  |       | Target worktree branch (default: current)       |
 | `--check`   |       | Show what would be done (dry-run)               |
 | `--force`   | `-f`  | Proceed even if target is dirty or HEAD moved   |
+| `--dirty`   |       | Include uncommitted changes from source worktree|
 | `--quiet`   | `-q`  | Suppress output                                 |
 | `--verbose` | `-v`  | Verbose output (use `-vv` for debug)            |
 
@@ -49,6 +50,39 @@ worktree.
 
 Files created by the user after overlay are preserved during restore.
 Only overlay-added files are removed.
+
+### Dirty Mode
+
+With `--dirty`, uncommitted changes from the source branch's worktree
+are applied on top of the committed overlay:
+
+1. Normal committed overlay is applied first
+2. Source worktree is located by branch name
+3. Each dirty file in the source worktree is copied to the target
+4. Deleted dirty files are removed from the target
+
+Requirements:
+
+- Source branch must have an existing worktree
+
+When source and target are at the same commit, `--dirty` allows the
+overlay to proceed (only dirty files are applied). Without dirty
+files, an error is returned.
+
+Untracked files in the source worktree are included and tracked
+for cleanup on restore.
+
+```bash
+# Overlay committed + uncommitted changes
+twig overlay feat/x --target main --dirty
+
+# Same commit, only dirty files
+twig overlay feat/x --dirty
+```
+
+Constraints:
+
+- Cannot be used with `--restore`
 
 ### Safety: Commit Prevention
 
@@ -136,6 +170,10 @@ With `--quiet`, no output is produced.
 | Submodules                    | Pointers updated, no init/deinit   |
 | Binary files                  | Handled by git checkout             |
 | Detached HEAD on target       | Works (recorded as "HEAD")          |
+| `--dirty` + same commit      | Only dirty files applied            |
+| `--dirty` without worktree   | Error (worktree required)           |
+| `--dirty` + `--restore`      | Error (mutually exclusive)          |
+| `--dirty` + no dirty files   | Error (same commit only)            |
 
 ## Examples
 
@@ -158,6 +196,12 @@ twig overlay --restore --target main
 
 # Force restore after accidental commit
 twig overlay --restore --target main --force
+
+# Include uncommitted changes from source worktree
+twig overlay feat/x --target main --dirty
+
+# Preview including dirty files
+twig overlay feat/x --target main --dirty --check
 ```
 
 ## Exit Code

--- a/git.go
+++ b/git.go
@@ -484,10 +484,21 @@ type FileStatus struct {
 }
 
 // ChangedFiles returns files with uncommitted changes including staged,
-// unstaged, and untracked files. Status codes are the first 2 characters
-// from git status --porcelain output.
+// unstaged, and untracked files. Untracked directories are collapsed
+// into a single entry. Status codes are the first 2 characters from
+// git status --porcelain output.
 func (g *GitRunner) ChangedFiles(ctx context.Context) ([]FileStatus, error) {
-	output, err := g.Run(ctx, GitCmdStatus, "--porcelain", "-unormal")
+	return g.changedFiles(ctx, "-unormal")
+}
+
+// ChangedFilesAll is like ChangedFiles but lists individual files within
+// untracked directories instead of collapsing them.
+func (g *GitRunner) ChangedFilesAll(ctx context.Context) ([]FileStatus, error) {
+	return g.changedFiles(ctx, "-uall")
+}
+
+func (g *GitRunner) changedFiles(ctx context.Context, untrackedMode string) ([]FileStatus, error) {
+	output, err := g.Run(ctx, GitCmdStatus, "--porcelain", untrackedMode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check git status: %w", err)
 	}

--- a/internal/testutil/mock_git.go
+++ b/internal/testutil/mock_git.go
@@ -62,6 +62,10 @@ type MockGitExecutor struct {
 	// If set, this overrides HasChanges.
 	StatusOutput string
 
+	// StatusOutputMap maps directory to custom status --porcelain output.
+	// Used when different worktrees need different status results.
+	StatusOutputMap map[string]string
+
 	// StashPushErr is returned when stash push is called.
 	StashPushErr error
 
@@ -178,7 +182,7 @@ func (m *MockGitExecutor) defaultRun(args ...string) ([]byte, error) {
 	case "branch":
 		return m.handleBranch(args)
 	case "status":
-		return m.handleStatus(args)
+		return m.handleStatus(args, dir)
 	case "stash":
 		return m.handleStash(args)
 	case "for-each-ref":
@@ -382,9 +386,15 @@ func (m *MockGitExecutor) handleBranch(args []string) ([]byte, error) {
 	return nil, nil
 }
 
-func (m *MockGitExecutor) handleStatus(args []string) ([]byte, error) {
+func (m *MockGitExecutor) handleStatus(args []string, dir string) ([]byte, error) {
 	// args: ["status", "--porcelain"]
 	if len(args) >= 2 && args[1] == "--porcelain" {
+		// Check directory-specific output first
+		if m.StatusOutputMap != nil && dir != "" {
+			if output, ok := m.StatusOutputMap[dir]; ok {
+				return []byte(output), nil
+			}
+		}
 		// Use StatusOutput if set (allows custom status output)
 		if m.StatusOutput != "" {
 			return []byte(m.StatusOutput), nil

--- a/overlay.go
+++ b/overlay.go
@@ -53,7 +53,6 @@ type overlayState struct {
 	TargetBranch string   `json:"target_branch"`
 	TargetCommit string   `json:"target_commit"`
 	AddedFiles   []string `json:"added_files,omitempty"`
-	Dirty        bool     `json:"dirty,omitempty"`
 	CreatedAt    string   `json:"created_at"`
 }
 
@@ -152,7 +151,6 @@ func (c *OverlayCommand) apply(ctx context.Context, sourceBranch string, cwd str
 		return result, fmt.Errorf("source and target are at the same commit")
 	}
 
-	// Committed diff (skipped when source and target are at the same commit)
 	if !sameCommit {
 		allChangedOut, err := targetGit.Run(ctx, GitCmdDiff, "--name-only", "HEAD", sourceCommit)
 		if err != nil {
@@ -184,9 +182,7 @@ func (c *OverlayCommand) apply(ctx context.Context, sourceBranch string, cwd str
 		}
 		sourceWtPath = sourceWt.Path
 		sourceGit := c.Git.InDir(sourceWtPath)
-		// Use -uall to list individual files within untracked directories.
-		// ChangedFiles() uses -unormal which collapses directories.
-		dirtyFiles, err = changedFilesAll(ctx, sourceGit)
+		dirtyFiles, err = sourceGit.ChangedFilesAll(ctx)
 		if err != nil {
 			return result, fmt.Errorf("failed to get dirty files from source: %w", err)
 		}
@@ -207,7 +203,6 @@ func (c *OverlayCommand) apply(ctx context.Context, sourceBranch string, cwd str
 		return result, nil
 	}
 
-	// Committed overlay (skipped when source and target are at the same commit)
 	if !sameCommit {
 		if _, err := targetGit.Run(ctx, GitCmdCheckout, sourceBranch, "--", "."); err != nil {
 			return result, fmt.Errorf("failed to checkout source files: %w", err)
@@ -227,7 +222,6 @@ func (c *OverlayCommand) apply(ctx context.Context, sourceBranch string, cwd str
 		}
 	}
 
-	// Dirty overlay
 	if opts.Dirty && len(dirtyFiles) > 0 {
 		dirtyAdded, err := c.copyDirtyFiles(ctx, dirtyFiles, sourceWtPath, targetPath)
 		if err != nil {
@@ -243,7 +237,6 @@ func (c *OverlayCommand) apply(ctx context.Context, sourceBranch string, cwd str
 		TargetBranch: targetBranch,
 		TargetCommit: targetCommit,
 		AddedFiles:   result.AddedFiles,
-		Dirty:        opts.Dirty,
 		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
 	}
 	stateData, err := json.MarshalIndent(state, "", "  ")
@@ -489,12 +482,11 @@ func (c *OverlayCommand) copyDirtyFiles(ctx context.Context, dirtyFiles []FileSt
 		srcPath := filepath.Join(sourceWtPath, f.Path)
 		dstPath := filepath.Join(targetPath, f.Path)
 
-		// Check if the file exists in the source worktree.
-		// Using Stat instead of parsing status codes handles edge cases
-		// like "DM" (staged delete then re-created) correctly.
-		_, statErr := c.FS.Stat(srcPath)
-		if statErr != nil && c.FS.IsNotExist(statErr) {
-			// File deleted in source worktree
+		// ReadFile directly instead of Stat-then-Read to avoid TOCTOU.
+		// This also handles edge cases like "DM" (staged delete then
+		// re-created) correctly by checking actual file existence.
+		data, readErr := c.FS.ReadFile(srcPath)
+		if readErr != nil && c.FS.IsNotExist(readErr) {
 			if err := c.FS.Remove(dstPath); err != nil && !c.FS.IsNotExist(err) {
 				c.Log.DebugContext(ctx, "failed to remove dirty-deleted file",
 					LogAttrKeyCategory.String(), LogCategoryOverlay,
@@ -502,13 +494,8 @@ func (c *OverlayCommand) copyDirtyFiles(ctx context.Context, dirtyFiles []FileSt
 			}
 			continue
 		}
-		if statErr != nil {
-			return nil, fmt.Errorf("failed to stat dirty file %s: %w", f.Path, statErr)
-		}
-
-		data, err := c.FS.ReadFile(srcPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read dirty file %s: %w", f.Path, err)
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to read dirty file %s: %w", f.Path, readErr)
 		}
 
 		if err := c.FS.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
@@ -541,29 +528,6 @@ func mergeUnique(a, b []string) []string {
 		}
 	}
 	return a
-}
-
-// changedFilesAll returns changed files using -uall to list individual files
-// within untracked directories instead of collapsing them.
-func changedFilesAll(ctx context.Context, git *GitRunner) ([]FileStatus, error) {
-	output, err := git.Run(ctx, GitCmdStatus, "--porcelain", "-uall")
-	if err != nil {
-		return nil, fmt.Errorf("failed to check git status: %w", err)
-	}
-
-	files := make([]FileStatus, 0)
-	for _, line := range strings.Split(string(output), "\n") {
-		if len(line) < 3 {
-			continue
-		}
-		status := line[:2]
-		path := strings.TrimSpace(line[2:])
-		if idx := strings.Index(path, " -> "); idx != -1 {
-			path = path[idx+4:]
-		}
-		files = append(files, FileStatus{Status: status, Path: path})
-	}
-	return files, nil
 }
 
 // splitNonEmpty splits a newline-separated string and removes empty entries.

--- a/overlay.go
+++ b/overlay.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"path/filepath"
 	"strings"
@@ -502,7 +503,13 @@ func (c *OverlayCommand) copyDirtyFiles(ctx context.Context, dirtyFiles []FileSt
 			return nil, fmt.Errorf("failed to create directory for %s: %w", f.Path, err)
 		}
 
-		if err := c.FS.WriteFile(dstPath, data, 0644); err != nil {
+		// Preserve source file permissions (e.g., executable bit).
+		perm := fs.FileMode(0644)
+		if info, err := c.FS.Stat(srcPath); err == nil {
+			perm = info.Mode().Perm()
+		}
+
+		if err := c.FS.WriteFile(dstPath, data, perm); err != nil {
 			return nil, fmt.Errorf("failed to write dirty file %s: %w", f.Path, err)
 		}
 

--- a/overlay.go
+++ b/overlay.go
@@ -22,6 +22,7 @@ type OverlayOptions struct {
 	Restore bool   // Restore the target worktree to its original state
 	Check   bool   // Dry-run mode
 	Force   bool   // Proceed even if target is dirty or HEAD has moved
+	Dirty   bool   // Include uncommitted changes from source worktree
 	Target  string // Target branch (empty = current worktree)
 }
 
@@ -36,6 +37,7 @@ type OverlayResult struct {
 	ModifiedFiles int
 	DeletedFiles  []string
 	AddedFiles    []string
+	DirtyFiles    int
 }
 
 // OverlayFormatOptions configures overlay output formatting.
@@ -51,6 +53,7 @@ type overlayState struct {
 	TargetBranch string   `json:"target_branch"`
 	TargetCommit string   `json:"target_commit"`
 	AddedFiles   []string `json:"added_files,omitempty"`
+	Dirty        bool     `json:"dirty,omitempty"`
 	CreatedAt    string   `json:"created_at"`
 }
 
@@ -88,7 +91,8 @@ func (c *OverlayCommand) apply(ctx context.Context, sourceBranch string, cwd str
 		"source", sourceBranch,
 		"target", opts.Target,
 		"check", opts.Check,
-		"force", opts.Force)
+		"force", opts.Force,
+		"dirty", opts.Dirty)
 
 	var result OverlayResult
 	result.SourceBranch = sourceBranch
@@ -142,61 +146,94 @@ func (c *OverlayCommand) apply(ctx context.Context, sourceBranch string, cwd str
 	}
 	targetCommit := strings.TrimSpace(string(targetCommitOut))
 
-	// Source == target check
-	if sourceCommit == targetCommit {
+	// Source == target check (relaxed when --dirty is set)
+	sameCommit := sourceCommit == targetCommit
+	if sameCommit && !opts.Dirty {
 		return result, fmt.Errorf("source and target are at the same commit")
 	}
 
-	// Get all changed files in a single diff, then filter by type.
-	// This avoids running three separate git diff commands.
-	allChangedOut, err := targetGit.Run(ctx, GitCmdDiff, "--name-only", "HEAD", sourceCommit)
-	if err != nil {
-		return result, fmt.Errorf("failed to diff: %w", err)
-	}
-	allChanged := splitNonEmpty(string(allChangedOut))
-	result.ModifiedFiles = len(allChanged)
+	// Committed diff (skipped when source and target are at the same commit)
+	if !sameCommit {
+		allChangedOut, err := targetGit.Run(ctx, GitCmdDiff, "--name-only", "HEAD", sourceCommit)
+		if err != nil {
+			return result, fmt.Errorf("failed to diff: %w", err)
+		}
+		allChanged := splitNonEmpty(string(allChangedOut))
+		result.ModifiedFiles = len(allChanged)
 
-	// Identify deleted files (in HEAD but not in source)
-	deletedOut, err := targetGit.Run(ctx, GitCmdDiff, "--name-only", "--diff-filter=D", "HEAD", sourceCommit)
-	if err != nil {
-		return result, fmt.Errorf("failed to diff for deleted files: %w", err)
-	}
-	result.DeletedFiles = splitNonEmpty(string(deletedOut))
+		deletedOut, err := targetGit.Run(ctx, GitCmdDiff, "--name-only", "--diff-filter=D", "HEAD", sourceCommit)
+		if err != nil {
+			return result, fmt.Errorf("failed to diff for deleted files: %w", err)
+		}
+		result.DeletedFiles = splitNonEmpty(string(deletedOut))
 
-	// Identify added files (in source but not in HEAD)
-	addedOut, err := targetGit.Run(ctx, GitCmdDiff, "--name-only", "--diff-filter=A", "HEAD", sourceCommit)
-	if err != nil {
-		return result, fmt.Errorf("failed to diff for added files: %w", err)
+		addedOut, err := targetGit.Run(ctx, GitCmdDiff, "--name-only", "--diff-filter=A", "HEAD", sourceCommit)
+		if err != nil {
+			return result, fmt.Errorf("failed to diff for added files: %w", err)
+		}
+		result.AddedFiles = splitNonEmpty(string(addedOut))
 	}
-	result.AddedFiles = splitNonEmpty(string(addedOut))
+
+	// Resolve dirty files from source worktree (before check mode early return)
+	var dirtyFiles []FileStatus
+	var sourceWtPath string
+	if opts.Dirty {
+		sourceWt, err := c.Git.WorktreeFindByBranch(ctx, sourceBranch)
+		if err != nil {
+			return result, fmt.Errorf("--dirty requires source branch %q to have a worktree: %w", sourceBranch, err)
+		}
+		sourceWtPath = sourceWt.Path
+		sourceGit := c.Git.InDir(sourceWtPath)
+		// Use -uall to list individual files within untracked directories.
+		// ChangedFiles() uses -unormal which collapses directories.
+		dirtyFiles, err = changedFilesAll(ctx, sourceGit)
+		if err != nil {
+			return result, fmt.Errorf("failed to get dirty files from source: %w", err)
+		}
+		result.DirtyFiles = len(dirtyFiles)
+
+		if sameCommit && len(dirtyFiles) == 0 {
+			return result, fmt.Errorf("source and target are at the same commit and source has no uncommitted changes")
+		}
+	}
 
 	if opts.Check {
 		c.Log.DebugContext(ctx, "apply check completed",
 			LogAttrKeyCategory.String(), LogCategoryOverlay,
 			"modifiedFiles", result.ModifiedFiles,
 			"deletedFiles", len(result.DeletedFiles),
-			"addedFiles", len(result.AddedFiles))
+			"addedFiles", len(result.AddedFiles),
+			"dirtyFiles", result.DirtyFiles)
 		return result, nil
 	}
 
-	// Checkout source branch files onto target
-	if _, err := targetGit.Run(ctx, GitCmdCheckout, sourceBranch, "--", "."); err != nil {
-		return result, fmt.Errorf("failed to checkout source files: %w", err)
-	}
+	// Committed overlay (skipped when source and target are at the same commit)
+	if !sameCommit {
+		if _, err := targetGit.Run(ctx, GitCmdCheckout, sourceBranch, "--", "."); err != nil {
+			return result, fmt.Errorf("failed to checkout source files: %w", err)
+		}
 
-	// Delete files that exist in target HEAD but not in source
-	for _, f := range result.DeletedFiles {
-		path := filepath.Join(targetPath, f)
-		if err := c.FS.Remove(path); err != nil && !c.FS.IsNotExist(err) {
-			c.Log.DebugContext(ctx, "failed to remove file",
-				LogAttrKeyCategory.String(), LogCategoryOverlay,
-				"file", f, "error", err)
+		for _, f := range result.DeletedFiles {
+			path := filepath.Join(targetPath, f)
+			if err := c.FS.Remove(path); err != nil && !c.FS.IsNotExist(err) {
+				c.Log.DebugContext(ctx, "failed to remove file",
+					LogAttrKeyCategory.String(), LogCategoryOverlay,
+					"file", f, "error", err)
+			}
+		}
+
+		if _, err := targetGit.Run(ctx, GitCmdReset, "HEAD"); err != nil {
+			return result, fmt.Errorf("failed to unstage changes: %w", err)
 		}
 	}
 
-	// Unstage all changes
-	if _, err := targetGit.Run(ctx, GitCmdReset, "HEAD"); err != nil {
-		return result, fmt.Errorf("failed to unstage changes: %w", err)
+	// Dirty overlay
+	if opts.Dirty && len(dirtyFiles) > 0 {
+		dirtyAdded, err := c.copyDirtyFiles(ctx, dirtyFiles, sourceWtPath, targetPath)
+		if err != nil {
+			return result, err
+		}
+		result.AddedFiles = mergeUnique(result.AddedFiles, dirtyAdded)
 	}
 
 	// Write state file
@@ -206,6 +243,7 @@ func (c *OverlayCommand) apply(ctx context.Context, sourceBranch string, cwd str
 		TargetBranch: targetBranch,
 		TargetCommit: targetCommit,
 		AddedFiles:   result.AddedFiles,
+		Dirty:        opts.Dirty,
 		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
 	}
 	stateData, err := json.MarshalIndent(state, "", "  ")
@@ -220,7 +258,8 @@ func (c *OverlayCommand) apply(ctx context.Context, sourceBranch string, cwd str
 		LogAttrKeyCategory.String(), LogCategoryOverlay,
 		"source", sourceBranch,
 		"target", targetBranch,
-		"modifiedFiles", result.ModifiedFiles)
+		"modifiedFiles", result.ModifiedFiles,
+		"dirtyFiles", result.DirtyFiles)
 
 	return result, nil
 }
@@ -376,6 +415,9 @@ func (r OverlayResult) Format(opts OverlayFormatOptions) FormatResult {
 			if len(r.AddedFiles) > 0 {
 				fmt.Fprintf(&stdout, "  %d file(s) would be added\n", len(r.AddedFiles))
 			}
+			if r.DirtyFiles > 0 {
+				fmt.Fprintf(&stdout, "  %d dirty file(s) would be applied\n", r.DirtyFiles)
+			}
 		}
 
 		if opts.Verbose {
@@ -406,6 +448,9 @@ func (r OverlayResult) Format(opts OverlayFormatOptions) FormatResult {
 		if len(r.AddedFiles) > 0 {
 			fmt.Fprintf(&stdout, ", %d added", len(r.AddedFiles))
 		}
+		if r.DirtyFiles > 0 {
+			fmt.Fprintf(&stdout, ", %d dirty", r.DirtyFiles)
+		}
 		fmt.Fprintln(&stdout, ")")
 
 		// Warning about not committing
@@ -429,6 +474,96 @@ func (r OverlayResult) Format(opts OverlayFormatOptions) FormatResult {
 	}
 
 	return FormatResult{Stdout: stdout.String(), Stderr: stderr.String()}
+}
+
+// copyDirtyFiles copies uncommitted changes from the source worktree to the target.
+// Returns the list of newly-added file paths for restore tracking.
+func (c *OverlayCommand) copyDirtyFiles(ctx context.Context, dirtyFiles []FileStatus, sourceWtPath, targetPath string) ([]string, error) {
+	c.Log.DebugContext(ctx, "applying dirty files",
+		LogAttrKeyCategory.String(), LogCategoryOverlay,
+		"count", len(dirtyFiles),
+		"source_worktree", sourceWtPath)
+
+	var addedFiles []string
+	for _, f := range dirtyFiles {
+		srcPath := filepath.Join(sourceWtPath, f.Path)
+		dstPath := filepath.Join(targetPath, f.Path)
+
+		// Check if the file exists in the source worktree.
+		// Using Stat instead of parsing status codes handles edge cases
+		// like "DM" (staged delete then re-created) correctly.
+		_, statErr := c.FS.Stat(srcPath)
+		if statErr != nil && c.FS.IsNotExist(statErr) {
+			// File deleted in source worktree
+			if err := c.FS.Remove(dstPath); err != nil && !c.FS.IsNotExist(err) {
+				c.Log.DebugContext(ctx, "failed to remove dirty-deleted file",
+					LogAttrKeyCategory.String(), LogCategoryOverlay,
+					"file", f.Path, "error", err)
+			}
+			continue
+		}
+		if statErr != nil {
+			return nil, fmt.Errorf("failed to stat dirty file %s: %w", f.Path, statErr)
+		}
+
+		data, err := c.FS.ReadFile(srcPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read dirty file %s: %w", f.Path, err)
+		}
+
+		if err := c.FS.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
+			return nil, fmt.Errorf("failed to create directory for %s: %w", f.Path, err)
+		}
+
+		if err := c.FS.WriteFile(dstPath, data, 0644); err != nil {
+			return nil, fmt.Errorf("failed to write dirty file %s: %w", f.Path, err)
+		}
+
+		// Track untracked and staged-new files for restore cleanup
+		if f.Status == "??" || strings.HasPrefix(f.Status, "A") {
+			addedFiles = append(addedFiles, f.Path)
+		}
+	}
+
+	return addedFiles, nil
+}
+
+// mergeUnique merges b into a, skipping duplicates.
+func mergeUnique(a, b []string) []string {
+	seen := make(map[string]bool, len(a))
+	for _, s := range a {
+		seen[s] = true
+	}
+	for _, s := range b {
+		if !seen[s] {
+			a = append(a, s)
+			seen[s] = true
+		}
+	}
+	return a
+}
+
+// changedFilesAll returns changed files using -uall to list individual files
+// within untracked directories instead of collapsing them.
+func changedFilesAll(ctx context.Context, git *GitRunner) ([]FileStatus, error) {
+	output, err := git.Run(ctx, GitCmdStatus, "--porcelain", "-uall")
+	if err != nil {
+		return nil, fmt.Errorf("failed to check git status: %w", err)
+	}
+
+	files := make([]FileStatus, 0)
+	for _, line := range strings.Split(string(output), "\n") {
+		if len(line) < 3 {
+			continue
+		}
+		status := line[:2]
+		path := strings.TrimSpace(line[2:])
+		if idx := strings.Index(path, " -> "); idx != -1 {
+			path = path[idx+4:]
+		}
+		files = append(files, FileStatus{Status: status, Path: path})
+	}
+	return files, nil
 }
 
 // splitNonEmpty splits a newline-separated string and removes empty entries.

--- a/overlay_integration_test.go
+++ b/overlay_integration_test.go
@@ -439,12 +439,8 @@ func TestOverlay_Integration(t *testing.T) {
 			t.Error("state file should be removed after restore")
 		}
 	})
-}
 
-func TestOverlayDirty_Integration(t *testing.T) {
-	t.Parallel()
-
-	t.Run("ApplyAndRestore", func(t *testing.T) {
+	t.Run("DirtyApplyAndRestore", func(t *testing.T) {
 		t.Parallel()
 
 		repoDir, mainDir := testutil.SetupTestRepo(t)
@@ -524,7 +520,7 @@ func TestOverlayDirty_Integration(t *testing.T) {
 		}
 	})
 
-	t.Run("SameCommit", func(t *testing.T) {
+	t.Run("DirtySameCommit", func(t *testing.T) {
 		t.Parallel()
 
 		repoDir, mainDir := testutil.SetupTestRepo(t)
@@ -586,7 +582,7 @@ func TestOverlayDirty_Integration(t *testing.T) {
 		}
 	})
 
-	t.Run("UntrackedFiles", func(t *testing.T) {
+	t.Run("DirtyUntrackedFiles", func(t *testing.T) {
 		t.Parallel()
 
 		repoDir, mainDir := testutil.SetupTestRepo(t)

--- a/overlay_integration_test.go
+++ b/overlay_integration_test.go
@@ -441,6 +441,207 @@ func TestOverlay_Integration(t *testing.T) {
 	})
 }
 
+func TestOverlayDirty_Integration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ApplyAndRestore", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		// Create committed content on main
+		writeFile(t, mainDir, "shared.txt", "main content")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "add files on main")
+
+		// Create feature branch with committed changes
+		testutil.RunGit(t, mainDir, "checkout", "-b", "feat/dirty")
+		writeFile(t, mainDir, "shared.txt", "committed feature content")
+		writeFile(t, mainDir, "committed-new.txt", "committed new")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "feature changes")
+		testutil.RunGit(t, mainDir, "checkout", "main")
+
+		// Create worktree for feat/dirty
+		wtPath := filepath.Join(repoDir, "feat-dirty-wt")
+		testutil.RunGit(t, mainDir, "worktree", "add", wtPath, "feat/dirty")
+
+		// Make uncommitted changes in the feature worktree
+		writeFile(t, wtPath, "shared.txt", "dirty feature content")
+		writeFile(t, wtPath, "untracked.txt", "untracked file")
+
+		// Apply dirty overlay from feat/dirty onto main
+		git := NewGitRunner(mainDir)
+		cmd := NewOverlayCommand(osFS{}, git, nil)
+
+		result, err := cmd.Run(t.Context(), "feat/dirty", mainDir, OverlayOptions{
+			Dirty: true,
+		})
+		if err != nil {
+			t.Fatalf("apply failed: %v", err)
+		}
+
+		if result.DirtyFiles != 2 {
+			t.Errorf("DirtyFiles = %d, want 2", result.DirtyFiles)
+		}
+
+		// shared.txt should have the dirty (not committed) content
+		content := readFile(t, mainDir, "shared.txt")
+		if content != "dirty feature content" {
+			t.Errorf("shared.txt = %q, want 'dirty feature content'", content)
+		}
+
+		// untracked.txt should exist (dirty untracked file)
+		if !fileExists(t, mainDir, "untracked.txt") {
+			t.Error("untracked.txt should exist after dirty overlay")
+		}
+
+		// committed-new.txt should also exist (from committed overlay)
+		if !fileExists(t, mainDir, "committed-new.txt") {
+			t.Error("committed-new.txt should exist from committed overlay")
+		}
+
+		// Restore
+		_, err = cmd.Run(t.Context(), "", mainDir, OverlayOptions{Restore: true})
+		if err != nil {
+			t.Fatalf("restore failed: %v", err)
+		}
+
+		// shared.txt should be back to main content
+		content = readFile(t, mainDir, "shared.txt")
+		if content != "main content" {
+			t.Errorf("shared.txt = %q after restore, want 'main content'", content)
+		}
+
+		// untracked.txt should be removed (was in AddedFiles)
+		if fileExists(t, mainDir, "untracked.txt") {
+			t.Error("untracked.txt should not exist after restore")
+		}
+
+		// committed-new.txt should also be removed
+		if fileExists(t, mainDir, "committed-new.txt") {
+			t.Error("committed-new.txt should not exist after restore")
+		}
+	})
+
+	t.Run("SameCommit", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		writeFile(t, mainDir, "file.txt", "original")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "add file")
+
+		// Create branch at same commit
+		testutil.RunGit(t, mainDir, "branch", "feat/same")
+
+		// Create worktree for feat/same
+		wtPath := filepath.Join(repoDir, "feat-same-wt")
+		testutil.RunGit(t, mainDir, "worktree", "add", wtPath, "feat/same")
+
+		// Make dirty changes in the feature worktree
+		writeFile(t, wtPath, "file.txt", "dirty content")
+		writeFile(t, wtPath, "new-dirty.txt", "brand new")
+
+		// Apply dirty overlay (same commit, only dirty files)
+		git := NewGitRunner(mainDir)
+		cmd := NewOverlayCommand(osFS{}, git, nil)
+
+		result, err := cmd.Run(t.Context(), "feat/same", mainDir, OverlayOptions{
+			Dirty: true,
+		})
+		if err != nil {
+			t.Fatalf("apply failed: %v", err)
+		}
+
+		if result.ModifiedFiles != 0 {
+			t.Errorf("ModifiedFiles = %d, want 0 (same commit)", result.ModifiedFiles)
+		}
+		if result.DirtyFiles != 2 {
+			t.Errorf("DirtyFiles = %d, want 2", result.DirtyFiles)
+		}
+
+		// file.txt should have dirty content
+		content := readFile(t, mainDir, "file.txt")
+		if content != "dirty content" {
+			t.Errorf("file.txt = %q, want 'dirty content'", content)
+		}
+
+		// Restore
+		_, err = cmd.Run(t.Context(), "", mainDir, OverlayOptions{Restore: true})
+		if err != nil {
+			t.Fatalf("restore failed: %v", err)
+		}
+
+		// file.txt back to original
+		content = readFile(t, mainDir, "file.txt")
+		if content != "original" {
+			t.Errorf("file.txt = %q after restore, want 'original'", content)
+		}
+
+		// new-dirty.txt should be cleaned up
+		if fileExists(t, mainDir, "new-dirty.txt") {
+			t.Error("new-dirty.txt should not exist after restore")
+		}
+	})
+
+	t.Run("UntrackedFiles", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		writeFile(t, mainDir, "tracked.txt", "tracked")
+		testutil.RunGit(t, mainDir, "add", ".")
+		testutil.RunGit(t, mainDir, "commit", "-m", "add file")
+
+		testutil.RunGit(t, mainDir, "branch", "feat/untracked")
+
+		wtPath := filepath.Join(repoDir, "feat-untracked-wt")
+		testutil.RunGit(t, mainDir, "worktree", "add", wtPath, "feat/untracked")
+
+		// Create untracked files in subdirectory
+		writeFile(t, wtPath, "subdir/new-file.txt", "new in subdir")
+		writeFile(t, wtPath, "another-new.txt", "another")
+
+		git := NewGitRunner(mainDir)
+		cmd := NewOverlayCommand(osFS{}, git, nil)
+
+		result, err := cmd.Run(t.Context(), "feat/untracked", mainDir, OverlayOptions{
+			Dirty: true,
+		})
+		if err != nil {
+			t.Fatalf("apply failed: %v", err)
+		}
+
+		if result.DirtyFiles != 2 {
+			t.Errorf("DirtyFiles = %d, want 2", result.DirtyFiles)
+		}
+
+		// Untracked files should exist in target
+		if !fileExists(t, mainDir, "subdir/new-file.txt") {
+			t.Error("subdir/new-file.txt should exist")
+		}
+		if !fileExists(t, mainDir, "another-new.txt") {
+			t.Error("another-new.txt should exist")
+		}
+
+		// Restore
+		_, err = cmd.Run(t.Context(), "", mainDir, OverlayOptions{Restore: true})
+		if err != nil {
+			t.Fatalf("restore failed: %v", err)
+		}
+
+		// Untracked files should be cleaned up
+		if fileExists(t, mainDir, "subdir/new-file.txt") {
+			t.Error("subdir/new-file.txt should not exist after restore")
+		}
+		if fileExists(t, mainDir, "another-new.txt") {
+			t.Error("another-new.txt should not exist after restore")
+		}
+	})
+}
+
 // Test helpers
 
 func writeFile(t *testing.T, dir, name, content string) {

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -546,6 +546,32 @@ func TestOverlayResult_Format(t *testing.T) {
 				"  1 overlay-added file(s) would be removed\n",
 		},
 		{
+			name: "apply_with_dirty",
+			result: OverlayResult{
+				TargetBranch:  "main",
+				SourceBranch:  "feat/x",
+				ModifiedFiles: 10,
+				DirtyFiles:    3,
+			},
+			opts:       OverlayFormatOptions{},
+			wantStdout: "Overlaid main with feat/x (10 files changed, 3 dirty)\n",
+			wantStderr: "warning: do not commit in the overlaid worktree.\n         Use 'twig overlay --restore' when done.\n",
+		},
+		{
+			name: "check_apply_with_dirty",
+			result: OverlayResult{
+				Check:         true,
+				TargetBranch:  "main",
+				SourceBranch:  "feat/x",
+				ModifiedFiles: 5,
+				DirtyFiles:    2,
+			},
+			opts: OverlayFormatOptions{},
+			wantStdout: "Would overlay main with feat/x:\n" +
+				"  5 file(s) would change\n" +
+				"  2 dirty file(s) would be applied\n",
+		},
+		{
 			name: "quiet_suppresses_output",
 			result: OverlayResult{
 				TargetBranch:  "main",
@@ -568,6 +594,235 @@ func TestOverlayResult_Format(t *testing.T) {
 			}
 			if formatted.Stderr != tt.wantStderr {
 				t.Errorf("Stderr:\ngot:  %q\nwant: %q", formatted.Stderr, tt.wantStderr)
+			}
+		})
+	}
+}
+
+func TestOverlayCommand_DirtyApply(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "main-commit"},
+				{Path: "/repo/feat-x", Branch: "feat/x", HEAD: "feat-x-commit"},
+			},
+			BranchHEADs: map[string]string{
+				"feat/x": "feat-x-commit",
+			},
+			DiffNameOnlyOutput: map[string]string{
+				"D:HEAD:feat-x-commit": "",
+				"A:HEAD:feat-x-commit": "new.go\n",
+				":HEAD:feat-x-commit":  "file.go\nnew.go\n",
+			},
+			// Dirty files in source worktree
+			StatusOutputMap: map[string]string{
+				"/repo/feat-x": " M file.go\n?? untracked.txt\n",
+			},
+		}
+		mockFS := &testutil.MockFS{
+			WrittenFiles: make(map[string][]byte),
+			ExistingPaths: []string{
+				"/repo/feat-x/file.go",
+				"/repo/feat-x/untracked.txt",
+			},
+			ReadFileResults: map[string][]byte{
+				"/repo/feat-x/file.go":       []byte("dirty content"),
+				"/repo/feat-x/untracked.txt": []byte("new file"),
+			},
+		}
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		result, err := cmd.Run(t.Context(), "feat/x", "/repo/main", OverlayOptions{
+			Target: "main",
+			Dirty:  true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.DirtyFiles != 2 {
+			t.Errorf("DirtyFiles = %d, want 2", result.DirtyFiles)
+		}
+		// untracked.txt should be in AddedFiles (dirty untracked)
+		found := false
+		for _, f := range result.AddedFiles {
+			if f == "untracked.txt" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("AddedFiles = %v, want to contain untracked.txt", result.AddedFiles)
+		}
+		// Dirty files should be written to target
+		if _, ok := mockFS.WrittenFiles["/repo/main/file.go"]; !ok {
+			t.Error("dirty file.go was not written to target")
+		}
+		if _, ok := mockFS.WrittenFiles["/repo/main/untracked.txt"]; !ok {
+			t.Error("dirty untracked.txt was not written to target")
+		}
+	})
+
+	t.Run("SameCommit_WithDirtyFiles", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "same-commit"},
+				{Path: "/repo/feat-x", Branch: "feat/x", HEAD: "same-commit"},
+			},
+			BranchHEADs: map[string]string{
+				"feat/x": "same-commit",
+			},
+			StatusOutputMap: map[string]string{
+				"/repo/feat-x": " M dirty.go\n",
+			},
+		}
+		mockFS := &testutil.MockFS{
+			WrittenFiles: make(map[string][]byte),
+			ExistingPaths: []string{
+				"/repo/feat-x/dirty.go",
+			},
+			ReadFileResults: map[string][]byte{
+				"/repo/feat-x/dirty.go": []byte("dirty"),
+			},
+		}
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		result, err := cmd.Run(t.Context(), "feat/x", "/repo/main", OverlayOptions{
+			Target: "main",
+			Dirty:  true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if result.DirtyFiles != 1 {
+			t.Errorf("DirtyFiles = %d, want 1", result.DirtyFiles)
+		}
+		// Committed diff should be 0 (same commit)
+		if result.ModifiedFiles != 0 {
+			t.Errorf("ModifiedFiles = %d, want 0", result.ModifiedFiles)
+		}
+	})
+
+	t.Run("SameCommit_NoDirtyFiles", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "same-commit"},
+				{Path: "/repo/feat-x", Branch: "feat/x", HEAD: "same-commit"},
+			},
+			BranchHEADs: map[string]string{
+				"feat/x": "same-commit",
+			},
+			StatusOutputMap: map[string]string{
+				"/repo/feat-x": "",
+			},
+		}
+		mockFS := &testutil.MockFS{}
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		_, err := cmd.Run(t.Context(), "feat/x", "/repo/main", OverlayOptions{
+			Target: "main",
+			Dirty:  true,
+		})
+		if err == nil {
+			t.Fatal("expected error for same commit with no dirty files")
+		}
+		if !strings.Contains(err.Error(), "same commit") || !strings.Contains(err.Error(), "no uncommitted") {
+			t.Errorf("error = %q, want to contain 'same commit' and 'no uncommitted'", err.Error())
+		}
+	})
+
+	t.Run("CheckMode", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "main-commit"},
+				{Path: "/repo/feat-x", Branch: "feat/x", HEAD: "feat-x-commit"},
+			},
+			BranchHEADs: map[string]string{
+				"feat/x": "feat-x-commit",
+			},
+			DiffNameOnlyOutput: map[string]string{
+				"D:HEAD:feat-x-commit": "",
+				"A:HEAD:feat-x-commit": "",
+				":HEAD:feat-x-commit":  "file.go\n",
+			},
+			StatusOutputMap: map[string]string{
+				"/repo/feat-x": " M file.go\n?? new.txt\n",
+			},
+		}
+		mockFS := &testutil.MockFS{
+			WrittenFiles: make(map[string][]byte),
+		}
+
+		git := &GitRunner{Executor: mockGit, Dir: "/repo/main", Log: NewNopLogger()}
+		cmd := NewOverlayCommand(mockFS, git, nil)
+
+		result, err := cmd.Run(t.Context(), "feat/x", "/repo/main", OverlayOptions{
+			Target: "main",
+			Dirty:  true,
+			Check:  true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.DirtyFiles != 2 {
+			t.Errorf("DirtyFiles = %d, want 2", result.DirtyFiles)
+		}
+		// No files should be written in check mode
+		// (state file and dirty files should not be written)
+		for path := range mockFS.WrittenFiles {
+			if !strings.Contains(path, "twig-overlay") {
+				continue
+			}
+			t.Errorf("state file should not be written in check mode: %s", path)
+		}
+	})
+}
+
+func TestMergeUnique(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want []string
+	}{
+		{"both_empty", nil, nil, nil},
+		{"b_empty", []string{"a", "b"}, nil, []string{"a", "b"}},
+		{"a_empty", nil, []string{"x"}, []string{"x"}},
+		{"no_overlap", []string{"a"}, []string{"b"}, []string{"a", "b"}},
+		{"with_overlap", []string{"a", "b"}, []string{"b", "c"}, []string{"a", "b", "c"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := mergeUnique(tt.a, tt.b)
+			if len(got) != len(tt.want) {
+				t.Errorf("mergeUnique(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+				return
+			}
+			for i, v := range got {
+				if v != tt.want[i] {
+					t.Errorf("mergeUnique(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+					return
+				}
 			}
 		})
 	}

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -625,10 +625,6 @@ func TestOverlayCommand_DirtyApply(t *testing.T) {
 		}
 		mockFS := &testutil.MockFS{
 			WrittenFiles: make(map[string][]byte),
-			ExistingPaths: []string{
-				"/repo/feat-x/file.go",
-				"/repo/feat-x/untracked.txt",
-			},
 			ReadFileResults: map[string][]byte{
 				"/repo/feat-x/file.go":       []byte("dirty content"),
 				"/repo/feat-x/untracked.txt": []byte("new file"),
@@ -685,9 +681,6 @@ func TestOverlayCommand_DirtyApply(t *testing.T) {
 		}
 		mockFS := &testutil.MockFS{
 			WrittenFiles: make(map[string][]byte),
-			ExistingPaths: []string{
-				"/repo/feat-x/dirty.go",
-			},
 			ReadFileResults: map[string][]byte{
 				"/repo/feat-x/dirty.go": []byte("dirty"),
 			},


### PR DESCRIPTION
## Overview

Add `--dirty` flag to `twig overlay` that includes uncommitted changes from the source branch's worktree.

## Why

`twig overlay` only overlaid committed file contents from a source branch. When working on a feature branch with uncommitted changes, there was no way to test those changes in the context of another worktree (e.g., main) without committing first.

## What

- Add `--dirty` flag to `twig overlay` that copies uncommitted changes (modified, untracked, deleted files) from the source worktree on top of the committed overlay
- When source and target are at the same commit, `--dirty` allows the overlay to proceed with only dirty files applied
- Dirty untracked/new files are tracked in the overlay state for proper cleanup on `--restore`
- Extract `GitRunner.changedFiles()` private method to share parsing between `ChangedFiles()` (`-unormal`) and `ChangedFilesAll()` (`-uall`)
- Use `ReadFile`-first pattern instead of `Stat`-then-`ReadFile` to eliminate TOCTOU in `copyDirtyFiles()`

Key behaviors:
- Requires the source branch to have an existing worktree
- Uses `git status --porcelain -uall` to enumerate individual dirty files (including files in untracked subdirectories)
- `--dirty` + `--restore` is mutually exclusive
- Same commit + `--dirty` + no dirty files returns an error

## Type of Change

- [x] Feature
- [x] Refactoring

## How to Test

```bash
# Unit + integration tests
go test -tags=integration ./...

# Manual: create two worktrees, make dirty changes in one, overlay onto the other
twig add feat/test
# edit files in feat/test worktree without committing
twig overlay feat/test --target main --dirty
# verify dirty files appear in main worktree
twig overlay --restore --target main
```

## Checklist

- [x] Tests added (unit + integration)
- [x] Documentation updated (`docs/reference/commands/overlay.md`)
- [x] Plugin docs synced (`make sync-plugin-docs`)
- [x] Lint passes (`make lint`, 0 issues)