### PR TITLE
fix: exclude symlink-managed files from uncommitted changes detection

### DIFF
--- a/clean_integration_test.go
+++ b/clean_integration_test.go
@@ -1246,6 +1246,64 @@ func TestCleanCommand_Integration(t *testing.T) {
 		}
 	})
 
+	t.Run("ExcludesSymlinkManagedFiles", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		// Create a branch with a commit
+		wtPath := filepath.Join(repoDir, "feature", "symlink-only-change")
+		testutil.RunGit(t, mainDir, "worktree", "add", "-b", "feature/symlink-only-change", wtPath)
+
+		testFile := filepath.Join(wtPath, "test.txt")
+		if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		testutil.RunGit(t, wtPath, "add", "test.txt")
+		testutil.RunGit(t, wtPath, "commit", "-m", "test commit")
+
+		// Merge the branch to main
+		testutil.RunGit(t, mainDir, "merge", "--no-ff", "-m", "Merge feature/symlink-only-change", "feature/symlink-only-change")
+
+		// Simulate a twig-managed symlink left in the worktree (e.g. justfile
+		// created by `twig add` via the symlinks setting).
+		symlinkTarget := filepath.Join(mainDir, "justfile")
+		if err := os.WriteFile(symlinkTarget, []byte("build:\n\tgo build\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(symlinkTarget, filepath.Join(wtPath, "justfile")); err != nil {
+			t.Fatal(err)
+		}
+
+		cfgResult, err := LoadConfig(mainDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfgResult.Config.Symlinks = []string{"justfile"}
+
+		cmd := &CleanCommand{
+			FS:     osFS{},
+			Git:    NewGitRunner(mainDir),
+			Config: cfgResult.Config,
+			Log:    NewNopLogger(),
+		}
+
+		// Without --stale, a merged worktree whose only untracked path is a
+		// symlink-managed file should still be cleanable (not skipped).
+		result, err := cmd.Run(t.Context(), mainDir, CleanOptions{Check: true})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+		if result.Candidates[0].Skipped {
+			t.Errorf("merged branch with only symlink-managed changes should not be skipped, reason: %s", result.Candidates[0].SkipReason)
+		}
+		for _, f := range result.Candidates[0].ChangedFiles {
+			if f.Path == "justfile" {
+				t.Error("symlink-managed justfile should be excluded from ChangedFiles")
+			}
+		}
+	})
+
 	t.Run("StaleOverridesMergedWithChanges", func(t *testing.T) {
 		t.Parallel()
 

--- a/docs/reference/commands/clean.md
+++ b/docs/reference/commands/clean.md
@@ -58,6 +58,11 @@ All conditions must pass for a worktree to be cleaned:
 | Not current        | Not the current directory                        |
 | Not main           | Not the main worktree                            |
 
+Files matching the `symlinks`/`extra_symlinks` patterns (see
+[Configuration](../configuration.md#symlinks)) are excluded from the
+"No changes" check, since they are twig-managed symlinks rather than
+genuine changes.
+
 ### Prunable Branches
 
 When a worktree directory is deleted externally (via `rm -rf` or other means),

--- a/docs/reference/commands/remove.md
+++ b/docs/reference/commands/remove.md
@@ -36,6 +36,11 @@ twig remove <branch>... [flags]
 This matches git's behavior where `git worktree remove -f` removes unclean
 worktrees and `git worktree remove -f -f` also removes locked worktrees.
 
+Files matching the `symlinks`/`extra_symlinks` patterns (see
+[Configuration](../configuration.md#symlinks)) are excluded from
+uncommitted-changes detection, since they are twig-managed symlinks rather
+than genuine changes.
+
 ### Submodule Handling
 
 `git worktree remove` requires `--force` for any worktree containing initialized

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -48,6 +48,13 @@ Glob patterns for files to symlink from source worktree to new worktrees.
 symlinks = [".envrc", "config/**/*.toml"]
 ```
 
+Since these symlinks are untracked, `git status` reports them the same way
+as ordinary untracked files. The [clean](commands/clean.md) and
+[remove](commands/remove.md) commands match `symlinks` (including
+`extra_symlinks`) against each worktree's untracked files and exclude the
+matches from uncommitted-changes detection, so a worktree with only
+symlinked files is still treated as clean.
+
 ### extra_symlinks
 
 Additional symlink patterns. Collected from both project and local configs.

--- a/external/claude-code/plugins/twig/.claude-plugin/plugin.json
+++ b/external/claude-code/plugins/twig/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "twig",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Claude Code plugin for twig - simplifies git worktree workflows",
   "author": {
     "name": "708u"

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/commands/clean.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/commands/clean.md
@@ -58,6 +58,11 @@ All conditions must pass for a worktree to be cleaned:
 | Not current        | Not the current directory                        |
 | Not main           | Not the main worktree                            |
 
+Files matching the `symlinks`/`extra_symlinks` patterns (see
+[Configuration](../configuration.md#symlinks)) are excluded from the
+"No changes" check, since they are twig-managed symlinks rather than
+genuine changes.
+
 ### Prunable Branches
 
 When a worktree directory is deleted externally (via `rm -rf` or other means),

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/commands/remove.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/commands/remove.md
@@ -36,6 +36,11 @@ twig remove <branch>... [flags]
 This matches git's behavior where `git worktree remove -f` removes unclean
 worktrees and `git worktree remove -f -f` also removes locked worktrees.
 
+Files matching the `symlinks`/`extra_symlinks` patterns (see
+[Configuration](../configuration.md#symlinks)) are excluded from
+uncommitted-changes detection, since they are twig-managed symlinks rather
+than genuine changes.
+
 ### Submodule Handling
 
 `git worktree remove` requires `--force` for any worktree containing initialized

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/configuration.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/configuration.md
@@ -48,6 +48,13 @@ Glob patterns for files to symlink from source worktree to new worktrees.
 symlinks = [".envrc", "config/**/*.toml"]
 ```
 
+Since these symlinks are untracked, `git status` reports them the same way
+as ordinary untracked files. The [clean](commands/clean.md) and
+[remove](commands/remove.md) commands match `symlinks` (including
+`extra_symlinks`) against each worktree's untracked files and exclude the
+matches from uncommitted-changes detection, so a worktree with only
+symlinked files is still treated as clean.
+
 ### extra_symlinks
 
 Additional symlink patterns. Collected from both project and local configs.

--- a/remove.go
+++ b/remove.go
@@ -536,6 +536,16 @@ func (c *RemoveCommand) Check(ctx context.Context, branch string, opts CheckOpti
 			// git status failed - return error to caller for proper handling
 			return result, fmt.Errorf("failed to check uncommitted changes: %w", err)
 		}
+		// Twig-managed symlinks show up as untracked in git status; exclude
+		// them so they are not mistaken for genuine uncommitted changes.
+		var excludedSymlinks []string
+		changedFiles, excludedSymlinks = filterSymlinkManagedFiles(c.FS, wtInfo.Path, c.Config.Symlinks, changedFiles)
+		if len(excludedSymlinks) > 0 {
+			c.Log.DebugContext(ctx, "excluded symlink-managed paths from changed files",
+				"category", LogCategoryRemove,
+				"branch", branch,
+				"paths", excludedSymlinks)
+		}
 		result.ChangedFiles = changedFiles
 		if reason := c.checkSkipReason(ctx, wt, opts, changedFiles); reason != "" {
 			result.CanRemove = false

--- a/remove_integration_test.go
+++ b/remove_integration_test.go
@@ -1325,6 +1325,81 @@ func TestRemoveCommand_Check_Integration(t *testing.T) {
 		}
 	})
 
+	t.Run("ExcludesSymlinkManagedFiles", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		wtPath := filepath.Join(repoDir, "feature", "symlink-test")
+		testutil.RunGit(t, mainDir, "worktree", "add", "-b", "feature/symlink-test", wtPath)
+
+		// Simulate a twig-managed symlink (e.g. created by `twig add`).
+		symlinkTarget := filepath.Join(mainDir, "justfile")
+		if err := os.WriteFile(symlinkTarget, []byte("build:\n\tgo build\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(symlinkTarget, filepath.Join(wtPath, "justfile")); err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := &RemoveCommand{
+			FS:  osFS{},
+			Git: NewGitRunner(mainDir),
+			Config: &Config{
+				WorktreeSourceDir: mainDir,
+				Symlinks:          []string{"justfile"},
+			},
+			Log: NewNopLogger(),
+		}
+
+		checkResult, err := cmd.Check(t.Context(), "feature/symlink-test", CheckOptions{
+			Cwd: mainDir,
+		})
+		if err != nil {
+			t.Fatalf("Check failed: %v", err)
+		}
+
+		for _, f := range checkResult.ChangedFiles {
+			if f.Path == "justfile" {
+				t.Error("symlink-managed justfile should be excluded from ChangedFiles")
+			}
+		}
+		if !checkResult.CanRemove {
+			t.Errorf("CanRemove should be true when only symlink-managed files changed, got SkipReason=%v", checkResult.SkipReason)
+		}
+
+		// A genuine untracked file must still be reported and block removal.
+		if err := os.WriteFile(filepath.Join(wtPath, "debug.log"), []byte("log"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		checkResult, err = cmd.Check(t.Context(), "feature/symlink-test", CheckOptions{
+			Cwd: mainDir,
+		})
+		if err != nil {
+			t.Fatalf("Check failed: %v", err)
+		}
+
+		var foundDebugLog bool
+		for _, f := range checkResult.ChangedFiles {
+			if f.Path == "justfile" {
+				t.Error("symlink-managed justfile should still be excluded from ChangedFiles")
+			}
+			if f.Path == "debug.log" {
+				foundDebugLog = true
+			}
+		}
+		if !foundDebugLog {
+			t.Error("expected debug.log to remain in ChangedFiles")
+		}
+		if checkResult.CanRemove {
+			t.Error("CanRemove should be false when a genuine untracked file exists")
+		}
+		if checkResult.SkipReason != SkipHasChanges {
+			t.Errorf("SkipReason = %v, want %v", checkResult.SkipReason, SkipHasChanges)
+		}
+	})
+
 	t.Run("BlocksRemovalFromNestedSubdir", func(t *testing.T) {
 		t.Parallel()
 

--- a/remove_test.go
+++ b/remove_test.go
@@ -842,6 +842,7 @@ func TestRemoveCommand_Check(t *testing.T) {
 		opts          CheckOptions
 		config        *Config
 		setupGit      func() *testutil.MockGitExecutor
+		fs            *testutil.MockFS
 		wantCanRemove bool
 		wantSkip      SkipReason
 		wantClean     CleanReason
@@ -970,6 +971,55 @@ func TestRemoveCommand_Check(t *testing.T) {
 			},
 			wantCanRemove: false,
 			wantSkip:      SkipHasChanges,
+		},
+		{
+			name:   "symlink_managed_untracked_file_not_treated_as_change",
+			branch: "feat/a",
+			opts: CheckOptions{
+				Force:  WorktreeForceLevelNone,
+				Target: "main",
+				Cwd:    "/other/dir",
+			},
+			config: &Config{WorktreeSourceDir: "/repo/main", Symlinks: []string{"justfile"}},
+			setupGit: func() *testutil.MockGitExecutor {
+				return &testutil.MockGitExecutor{
+					Worktrees: []testutil.MockWorktree{
+						{Path: "/repo/feat/a", Branch: "feat/a"},
+					},
+					MergedBranches: map[string][]string{"main": {"feat/a"}},
+					StatusOutput:   "?? justfile\n",
+				}
+			},
+			fs: &testutil.MockFS{
+				GlobResults: map[string][]string{"justfile": {"justfile"}},
+			},
+			wantCanRemove: true,
+			wantClean:     CleanMerged,
+		},
+		{
+			name:   "non_symlink_untracked_file_still_skips",
+			branch: "feat/a",
+			opts: CheckOptions{
+				Force:  WorktreeForceLevelNone,
+				Target: "main",
+				Cwd:    "/other/dir",
+			},
+			config: &Config{WorktreeSourceDir: "/repo/main", Symlinks: []string{"justfile"}},
+			setupGit: func() *testutil.MockGitExecutor {
+				return &testutil.MockGitExecutor{
+					Worktrees: []testutil.MockWorktree{
+						{Path: "/repo/feat/a", Branch: "feat/a"},
+					},
+					MergedBranches: map[string][]string{"main": {"feat/a"}},
+					StatusOutput:   "?? debug.log\n",
+				}
+			},
+			fs: &testutil.MockFS{
+				GlobResults: map[string][]string{"justfile": {"justfile"}},
+			},
+			wantCanRemove: false,
+			wantSkip:      SkipHasChanges,
+			wantClean:     CleanMerged,
 		},
 		{
 			name:   "skip_not_merged",
@@ -1428,8 +1478,13 @@ func TestRemoveCommand_Check(t *testing.T) {
 
 			mockGit := tt.setupGit()
 
+			fs := tt.fs
+			if fs == nil {
+				fs = &testutil.MockFS{}
+			}
+
 			cmd := &RemoveCommand{
-				FS:     &testutil.MockFS{},
+				FS:     fs,
 				Git:    &GitRunner{Executor: mockGit, Log: NewNopLogger()},
 				Config: tt.config,
 				Log:    NewNopLogger(),

--- a/symlink.go
+++ b/symlink.go
@@ -70,3 +70,38 @@ func createSymlinks(fsys FileSystem, srcDir, dstDir string, patterns []string) (
 
 	return results, nil
 }
+
+// filterSymlinkManagedFiles removes entries from changedFiles whose path
+// matches one of the symlink glob patterns evaluated against dir. It returns
+// the filtered list and the paths that were excluded.
+func filterSymlinkManagedFiles(fsys FileSystem, dir string, patterns []string, changedFiles []FileStatus) ([]FileStatus, []string) {
+	if len(patterns) == 0 || len(changedFiles) == 0 {
+		return changedFiles, nil
+	}
+
+	symlinkPaths := make(map[string]bool)
+	for _, pattern := range patterns {
+		matches, err := fsys.Glob(dir, pattern)
+		if err != nil {
+			// An invalid pattern should not block uncommitted-changes detection.
+			continue
+		}
+		for _, m := range matches {
+			symlinkPaths[m] = true
+		}
+	}
+	if len(symlinkPaths) == 0 {
+		return changedFiles, nil
+	}
+
+	filtered := make([]FileStatus, 0, len(changedFiles))
+	var excluded []string
+	for _, f := range changedFiles {
+		if symlinkPaths[f.Path] {
+			excluded = append(excluded, f.Path)
+			continue
+		}
+		filtered = append(filtered, f)
+	}
+	return filtered, excluded
+}


### PR DESCRIPTION
## Overview

`twig clean --stale --check` lists twig-managed symlinks (e.g. `justfile`) as uncommitted changes, even though they are not genuine changes.

## Why

`git status` cannot distinguish a twig-managed symlink from a real untracked file, so any path matching the `symlinks`/`extra_symlinks` config always shows up as `??` in `git status --porcelain`. `RemoveCommand.Check` fed that raw output straight into `checkSkipReason`, so a worktree whose only "change" was a symlink was treated as dirty (`SkipHasChanges`). `--stale` does not help here either: it only waives the changes check for branches that are already merged/upstream-gone, it does not remove symlink paths from the `ChangedFiles` list used by `--check`.

## What

- Added `filterSymlinkManagedFiles` in `symlink.go`, which reuses the existing `FileSystem.Glob` based matching (already used by `createSymlinks`) to compute the set of paths a worktree's `symlinks`/`extra_symlinks` patterns resolve to, and removes matching entries from a `[]FileStatus` list.
- `RemoveCommand.Check` now applies this filter to the result of `ChangedFiles` right after fetching it, before it reaches `checkSkipReason`. The same filtered list is stored in `CheckResult.ChangedFiles`, so `--verbose` output and the skip-reason judgment stay consistent (a single filtered result, not two separate exclusion rules).
- Excluded paths are logged via `DebugContext` for traceability.
- Documented the behavior in `docs/reference/configuration.md`, `docs/reference/commands/clean.md`, and `docs/reference/commands/remove.md`, and synced plugin docs with `make sync-plugin-docs` (plugin version bumped 0.13.0 → 0.13.1, patch: behavior clarification without new commands).

## Related

N/A

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD
- [ ] Performance
- [ ] Other

## How to Test

```bash
go test -tags=integration ./...
make lint
```

Manual repro before the fix, using this repo's own `.twig/settings.local.toml` symlinks config:

```bash
twig add some/branch
twig clean --stale --check   # lists symlinked paths (e.g. justfile) as changed
```

After the fix, a worktree whose only untracked paths are symlink-managed is treated as clean; a worktree with a genuine untracked file is still correctly skipped.

## Checklist

- [x] Tests added/updated (unit tests in `remove_test.go`, integration tests in `remove_integration_test.go` and `clean_integration_test.go`)
- [x] Self-reviewed
