### PR TITLE
perf(clean): reuse check results to cut redundant git subprocesses

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -55,7 +55,8 @@ type CleanCandidate struct {
 	SkipReason    SkipReason
 	CleanReason   CleanReason
 	ChangedFiles  []FileStatus
-	StaleOverride bool // Changes check bypassed via --stale for merged/upstream-gone
+	StaleOverride bool         // Changes check bypassed via --stale for merged/upstream-gone
+	checkResult   *CheckResult // cached Check result, reused by the removal phase
 }
 
 // CleanResult aggregates results from clean operations.
@@ -250,18 +251,19 @@ func (c *CleanCommand) Run(ctx context.Context, cwd string, opts CleanOptions) (
 		"count", len(worktrees))
 
 	// Pre-fetch branch merge status to avoid redundant git branch --merged calls
-	mergeStatus, err := c.Git.ClassifyBranchMergeStatus(ctx, target)
-	if err != nil {
+	var mergeStatus *BranchMergeStatus
+	if ms, err := c.Git.ClassifyBranchMergeStatus(ctx, target); err != nil {
 		c.Log.DebugContext(ctx, "failed to classify branch merge status",
 			LogAttrKeyCategory.String(), LogCategoryClean,
 			"error", err.Error())
 		// Continue without cache - Check() will fall back to individual calls
-		mergeStatus = BranchMergeStatus{}
 	} else {
+		mergeStatus = &ms
 		c.Log.DebugContext(ctx, "branch merge status classified",
 			LogAttrKeyCategory.String(), LogCategoryClean,
-			"mergedCount", len(mergeStatus.Merged),
-			"sameCommitCount", len(mergeStatus.SameCommit))
+			"mergedCount", len(ms.Merged),
+			"sameCommitCount", len(ms.SameCommit),
+			"goneCount", len(ms.Gone))
 	}
 
 	// RemoveCommand is used for both Check and Run
@@ -344,6 +346,7 @@ func (c *CleanCommand) Run(ctx context.Context, cwd string, opts CleanOptions) (
 				SkipReason:   checkResult.SkipReason,
 				CleanReason:  checkResult.CleanReason,
 				ChangedFiles: checkResult.ChangedFiles,
+				checkResult:  &checkResult,
 			}
 
 			c.Log.DebugContext(ctx, "check completed",
@@ -427,12 +430,21 @@ func (c *CleanCommand) Run(ctx context.Context, cwd string, opts CleanOptions) (
 				"branch", candidate.Branch)
 
 			effectiveForce := opts.Force
-			if candidate.StaleOverride && effectiveForce < WorktreeForceLevelUnclean {
-				effectiveForce = WorktreeForceLevelUnclean
+			var preChecked *CheckResult
+			if candidate.StaleOverride {
+				// Stale bypasses the changes/submodule checks that the cached
+				// result recorded as a skip reason (CanRemove=false), so re-check
+				// with the elevated force instead of reusing that result.
+				if effectiveForce < WorktreeForceLevelUnclean {
+					effectiveForce = WorktreeForceLevelUnclean
+				}
+			} else {
+				preChecked = candidate.checkResult
 			}
 			wt, err := removeCmd.Run(ctx, candidate.Branch, cwd, RemoveOptions{
-				Force: effectiveForce,
-				Check: false,
+				Force:      effectiveForce,
+				Check:      false,
+				PreChecked: preChecked,
 			})
 			if err != nil {
 				c.Log.DebugContext(ctx, "removal failed",

--- a/clean_test.go
+++ b/clean_test.go
@@ -1,11 +1,114 @@
 package twig
 
 import (
+	"context"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/708u/twig/internal/testutil"
 )
+
+// countingExecutor wraps a GitExecutor and counts calls per git subcommand.
+type countingExecutor struct {
+	inner  GitExecutor
+	mu     sync.Mutex
+	counts map[string]int
+	total  int
+}
+
+func newCountingExecutor(inner GitExecutor) *countingExecutor {
+	return &countingExecutor{inner: inner, counts: map[string]int{}}
+}
+
+func (e *countingExecutor) Run(ctx context.Context, args ...string) ([]byte, error) {
+	e.mu.Lock()
+	e.total++
+	e.counts[gitSubcommandKey(args)]++
+	e.mu.Unlock()
+	return e.inner.Run(ctx, args...)
+}
+
+// gitSubcommandKey derives a stable key from git args, ignoring the -C <dir>
+// prefix. Subcommands whose cost depends on the second token (e.g. branch
+// --merged vs branch -d) are keyed on both tokens.
+func gitSubcommandKey(args []string) string {
+	for len(args) >= 2 && args[0] == "-C" {
+		args = args[2:]
+	}
+	if len(args) == 0 {
+		return ""
+	}
+	switch args[0] {
+	case "worktree", "submodule", "stash":
+		if len(args) >= 2 {
+			return args[0] + " " + args[1]
+		}
+	case "branch":
+		if len(args) >= 2 && (args[1] == "--merged" || args[1] == "-d" || args[1] == "-D") {
+			return "branch " + args[1]
+		}
+	}
+	return args[0]
+}
+
+// TestCleanCommand_Run_ReusesChecks verifies the removal phase reuses the
+// check phase results instead of re-running per-branch git queries.
+func TestCleanCommand_Run_ReusesChecks(t *testing.T) {
+	t.Parallel()
+
+	mockGit := &testutil.MockGitExecutor{
+		Worktrees: []testutil.MockWorktree{
+			{Path: "/repo/main", Branch: "main"},
+			{Path: "/repo/feat/a", Branch: "feat/a"},
+			{Path: "/repo/feat/b", Branch: "feat/b"},
+		},
+		MergedBranches: map[string][]string{
+			"main": {"main", "feat/a"},
+		},
+		UpstreamGoneBranches: []string{"feat/b"},
+	}
+	counter := newCountingExecutor(mockGit)
+
+	cmd := &CleanCommand{
+		FS:     &testutil.MockFS{},
+		Git:    &GitRunner{Executor: counter, Log: NewNopLogger()},
+		Config: &Config{WorktreeSourceDir: "/repo/main", DefaultSource: "main"},
+		Log:    NewNopLogger(),
+	}
+
+	result, err := cmd.Run(t.Context(), "/other/dir", CleanOptions{Yes: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.CleanableCount() != 2 {
+		t.Fatalf("expected 2 cleanable, got %d", result.CleanableCount())
+	}
+
+	// branch --merged and the repo-wide for-each-ref classification run once
+	// for the whole command, not once per candidate.
+	if got := counter.counts["branch --merged"]; got != 1 {
+		t.Errorf("branch --merged called %d times, want 1", got)
+	}
+	if got := counter.counts["for-each-ref"]; got != 1 {
+		t.Errorf("for-each-ref called %d times, want 1", got)
+	}
+	// Submodule status is checked once per candidate in the check phase and
+	// reused during removal, not re-fetched.
+	if got := counter.counts["submodule status"]; got != 2 {
+		t.Errorf("submodule status called %d times, want 2", got)
+	}
+	// Removal reuses the check result: only worktree remove + branch delete run.
+	if got := counter.counts["worktree remove"]; got != 2 {
+		t.Errorf("worktree remove called %d times, want 2", got)
+	}
+	if got := counter.counts["branch -d"]; got != 1 {
+		t.Errorf("branch -d (merged) called %d times, want 1", got)
+	}
+	if got := counter.counts["branch -D"]; got != 1 {
+		t.Errorf("branch -D (upstream gone) called %d times, want 1", got)
+	}
+}
 
 func TestCleanResult_CleanableCount(t *testing.T) {
 	t.Parallel()

--- a/git.go
+++ b/git.go
@@ -632,27 +632,53 @@ func (g *GitRunner) IsBranchMerged(ctx context.Context, branch, target string) (
 	if err != nil {
 		return false, err
 	}
-	return result.Merged[branch], nil
+	return result.IsMerged(branch), nil
 }
 
 // BranchMergeStatus holds the classification of branches by merge status.
 type BranchMergeStatus struct {
-	// Merged contains branches that are considered merged
-	// (via git branch --merged or upstream gone, excluding same-commit branches).
+	// Merged contains branches in `git branch --merged <target>` output,
+	// excluding branches pointing to the same commit as target.
 	Merged map[string]bool
 	// SameCommit contains branches pointing to the same commit as target.
 	// These are excluded from Merged because they could be newly created or ff-merged.
 	SameCommit map[string]bool
+	// Gone contains branches whose upstream tracking branch is gone,
+	// indicating a squash/rebase merge whose remote branch was deleted.
+	Gone map[string]bool
+}
+
+// IsMerged reports whether the branch is safe to treat as merged for removal:
+// reachable from target (git branch --merged) or with a gone upstream.
+// Same-commit branches are excluded since they may be unmerged work.
+func (s BranchMergeStatus) IsMerged(branch string) bool {
+	return s.Merged[branch] || s.Gone[branch]
+}
+
+// CleanReason returns the display reason for why the branch is cleanable,
+// or empty if it is not merged. Presence in `git branch --merged` output
+// (including same-commit branches) takes precedence over a gone upstream,
+// matching git's merge detection order.
+func (s BranchMergeStatus) CleanReason(branch string) CleanReason {
+	if s.Merged[branch] || s.SameCommit[branch] {
+		return CleanMerged
+	}
+	if s.Gone[branch] {
+		return CleanUpstreamGone
+	}
+	return ""
 }
 
 // ClassifyBranchMergeStatus classifies branches by their merge status relative to target.
 // A branch is merged if it's in `git branch --merged <target>` or if its upstream is gone.
-// Branches pointing to the same commit as target are returned separately in SameCommit.
+// Branches pointing to the same commit as target are returned separately in SameCommit,
+// and branches with a gone upstream in Gone.
 // This is more efficient than calling IsBranchMerged for each branch individually.
 func (g *GitRunner) ClassifyBranchMergeStatus(ctx context.Context, target string) (BranchMergeStatus, error) {
 	result := BranchMergeStatus{
 		Merged:     make(map[string]bool),
 		SameCommit: make(map[string]bool),
+		Gone:       make(map[string]bool),
 	}
 
 	// Get all branch info in one call: name, commit hash, and upstream status
@@ -678,7 +704,7 @@ func (g *GitRunner) ClassifyBranchMergeStatus(ctx context.Context, target string
 
 		// Check for upstream gone (squash/rebase merges)
 		if len(parts) == 3 && parts[2] == "[gone]" {
-			result.Merged[branch] = true
+			result.Gone[branch] = true
 		}
 	}
 
@@ -749,8 +775,10 @@ const (
 type SubmoduleCleanStatus int
 
 const (
+	// SubmoduleCleanStatusUnknown: status not yet checked (zero value).
+	SubmoduleCleanStatusUnknown SubmoduleCleanStatus = iota
 	// SubmoduleCleanStatusNone: no initialized submodules exist.
-	SubmoduleCleanStatusNone SubmoduleCleanStatus = iota
+	SubmoduleCleanStatusNone
 	// SubmoduleCleanStatusClean: submodules exist but all are clean.
 	SubmoduleCleanStatusClean
 	// SubmoduleCleanStatusDirty: submodules have uncommitted changes or are at different commits.

--- a/git_test.go
+++ b/git_test.go
@@ -237,6 +237,73 @@ func TestGitRunner_IsFirstParentAncestor(t *testing.T) {
 	}
 }
 
+func TestBranchMergeStatus_Classification(t *testing.T) {
+	t.Parallel()
+
+	mockGit := &testutil.MockGitExecutor{
+		BranchHEADs: map[string]string{
+			"main":         "commit-main",
+			"feat/merged":  "commit-merged",
+			"feat/gone":    "commit-gone",
+			"feat/same":    "commit-main",
+			"feat/notdone": "commit-notdone",
+		},
+		MergedBranches: map[string][]string{
+			// git branch --merged includes same-commit branches.
+			"main": {"feat/merged", "feat/same"},
+		},
+		UpstreamGoneBranches: []string{"feat/gone"},
+	}
+	runner := &GitRunner{Executor: mockGit, Log: NewNopLogger()}
+
+	status, err := runner.ClassifyBranchMergeStatus(t.Context(), "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !status.Merged["feat/merged"] {
+		t.Error("feat/merged should be in Merged")
+	}
+	if status.Merged["feat/same"] {
+		t.Error("feat/same points to target commit and must be excluded from Merged")
+	}
+	if !status.SameCommit["feat/same"] {
+		t.Error("feat/same should be in SameCommit")
+	}
+	if !status.Gone["feat/gone"] {
+		t.Error("feat/gone should be in Gone")
+	}
+	if status.Merged["feat/gone"] {
+		t.Error("gone branches must not be recorded in Merged")
+	}
+
+	// IsMerged treats both traditional merge and gone upstream as removable.
+	for _, b := range []string{"feat/merged", "feat/gone"} {
+		if !status.IsMerged(b) {
+			t.Errorf("IsMerged(%q) = false, want true", b)
+		}
+	}
+	for _, b := range []string{"feat/same", "feat/notdone"} {
+		if status.IsMerged(b) {
+			t.Errorf("IsMerged(%q) = true, want false", b)
+		}
+	}
+
+	// CleanReason: traditional merge and same-commit both display as merged;
+	// gone-only displays as upstream gone.
+	cleanReasons := map[string]CleanReason{
+		"feat/merged":  CleanMerged,
+		"feat/same":    CleanMerged,
+		"feat/gone":    CleanUpstreamGone,
+		"feat/notdone": "",
+	}
+	for b, want := range cleanReasons {
+		if got := status.CleanReason(b); got != want {
+			t.Errorf("CleanReason(%q) = %q, want %q", b, got, want)
+		}
+	}
+}
+
 func TestGitRunner_IsBranchMerged_WithSquashMerge(t *testing.T) {
 	t.Parallel()
 

--- a/remove.go
+++ b/remove.go
@@ -50,13 +50,14 @@ const (
 
 // CheckResult holds the result of checking whether a worktree can be removed.
 type CheckResult struct {
-	CanRemove    bool         // Whether the worktree can be removed
-	SkipReason   SkipReason   // Reason if cannot be removed
-	CleanReason  CleanReason  // Reason if can be removed (for clean command display)
-	Prunable     bool         // Whether worktree is prunable (directory was deleted externally)
-	WorktreePath string       // Path to the worktree
-	Branch       string       // Branch name
-	ChangedFiles []FileStatus // Uncommitted changes (for verbose output)
+	CanRemove       bool                 // Whether the worktree can be removed
+	SkipReason      SkipReason           // Reason if cannot be removed
+	CleanReason     CleanReason          // Reason if can be removed (for clean command display)
+	Prunable        bool                 // Whether worktree is prunable (directory was deleted externally)
+	WorktreePath    string               // Path to the worktree
+	Branch          string               // Branch name
+	ChangedFiles    []FileStatus         // Uncommitted changes (for verbose output)
+	SubmoduleStatus SubmoduleCleanStatus // Submodule clean status (cached for Run reuse)
 }
 
 // CheckOptions configures the check operation.
@@ -65,7 +66,7 @@ type CheckOptions struct {
 	Target       string             // Target branch for merged check (empty = skip merged check)
 	Cwd          string             // Current directory for cwd check
 	WorktreeInfo *Worktree          // Pre-fetched worktree info (skips WorktreeFindByBranch if set)
-	MergeStatus  BranchMergeStatus  // Pre-fetched branch merge status (skips IsBranchMerged if set)
+	MergeStatus  *BranchMergeStatus // Pre-fetched branch merge status (nil = query per branch)
 }
 
 // RemoveCommand removes git worktrees with their associated branches.
@@ -80,8 +81,9 @@ type RemoveCommand struct {
 type RemoveOptions struct {
 	// Force specifies the force level.
 	// Matches git worktree behavior: -f for unclean, -f -f for locked.
-	Force WorktreeForceLevel
-	Check bool // Show what would be removed without making changes
+	Force      WorktreeForceLevel
+	Check      bool         // Show what would be removed without making changes
+	PreChecked *CheckResult // Pre-fetched Check result (skips Check if set)
 }
 
 // NewRemoveCommand creates a RemoveCommand with explicit dependencies.
@@ -258,19 +260,27 @@ func (c *RemoveCommand) Run(ctx context.Context, branch string, cwd string, opts
 		"category", LogCategoryRemove,
 		"branch", branch,
 		"check", opts.Check,
-		"force", opts.Force)
+		"force", opts.Force,
+		"preChecked", opts.PreChecked != nil)
 
 	var result RemovedWorktree
 	result.Branch = branch
 	result.Check = opts.Check
 
-	// Check removal eligibility first
-	checkResult, err := c.Check(ctx, branch, CheckOptions{
-		Force: opts.Force,
-		Cwd:   cwd,
-	})
-	if err != nil {
-		return result, err
+	// Reuse a pre-fetched check result when the caller already ran Check
+	// (e.g. the clean command), otherwise run it here.
+	var checkResult CheckResult
+	if opts.PreChecked != nil {
+		checkResult = *opts.PreChecked
+	} else {
+		var err error
+		checkResult, err = c.Check(ctx, branch, CheckOptions{
+			Force: opts.Force,
+			Cwd:   cwd,
+		})
+		if err != nil {
+			return result, err
+		}
 	}
 
 	// Copy check results
@@ -283,6 +293,7 @@ func (c *RemoveCommand) Run(ctx context.Context, branch string, cwd string, opts
 	c.Log.DebugContext(ctx, "check completed",
 		"category", LogCategoryRemove,
 		"canRemove", checkResult.CanRemove,
+		"preChecked", opts.PreChecked != nil,
 		"branch", branch)
 
 	if !checkResult.CanRemove {
@@ -294,24 +305,29 @@ func (c *RemoveCommand) Run(ctx context.Context, branch string, cwd string, opts
 		c.Log.DebugContext(ctx, "handling prunable worktree",
 			"category", LogCategoryRemove,
 			"branch", branch)
-		return c.removePrunable(ctx, branch, opts, result)
+		return c.removePrunable(ctx, branch, opts, checkResult, result)
 	}
 
-	// Check submodule status to determine effective force level.
-	// Clean submodules require auto-force for git worktree remove,
-	// but this is safe since Check() already verified no dirty submodules.
+	// Clean submodules require auto-force for git worktree remove. This only
+	// matters when force is not already elevated; Check() verified no dirty
+	// submodules, so the auto-force is safe.
 	effectiveForce := opts.Force
-	smStatus, err := c.Git.InDir(checkResult.WorktreePath).CheckSubmoduleCleanStatus(ctx)
-	if err == nil && smStatus == SubmoduleCleanStatusClean {
-		if effectiveForce < WorktreeForceLevelUnclean {
+	if effectiveForce < WorktreeForceLevelUnclean {
+		smStatus := checkResult.SubmoduleStatus
+		if smStatus == SubmoduleCleanStatusUnknown {
+			if s, err := c.Git.InDir(checkResult.WorktreePath).CheckSubmoduleCleanStatus(ctx); err == nil {
+				smStatus = s
+			}
+		}
+		if smStatus == SubmoduleCleanStatusClean {
 			effectiveForce = WorktreeForceLevelUnclean
 		}
+		c.Log.DebugContext(ctx, "submodule check",
+			"category", LogCategoryRemove,
+			"status", smStatus,
+			"effectiveForce", effectiveForce,
+			"branch", branch)
 	}
-	c.Log.DebugContext(ctx, "submodule check",
-		"category", LogCategoryRemove,
-		"status", smStatus,
-		"effectiveForce", effectiveForce,
-		"branch", branch)
 
 	if opts.Check {
 		result.CleanedDirs = c.predictEmptyParentDirs(checkResult.WorktreePath)
@@ -338,17 +354,14 @@ func (c *RemoveCommand) Run(ctx context.Context, branch string, cwd string, opts
 	}
 
 	var branchOpts []BranchDeleteOption
-	if opts.Force > WorktreeForceLevelNone {
+	switch {
+	case opts.Force > WorktreeForceLevelNone:
 		branchOpts = append(branchOpts, WithForceDelete())
-	} else {
-		// upstream gone (squash/rebase merge) requires -D since commits differ
-		// Run() reaches here only after Check() verified no uncommitted changes
-		if gone, err := c.Git.IsBranchUpstreamGone(ctx, branch); err == nil && gone {
-			c.Log.DebugContext(ctx, "upstream gone, using force delete",
-				"category", LogCategoryRemove,
-				"branch", branch)
-			branchOpts = append(branchOpts, WithForceDelete())
-		}
+	case c.shouldForceDeleteBranch(ctx, branch, checkResult):
+		c.Log.DebugContext(ctx, "upstream gone, using force delete",
+			"category", LogCategoryRemove,
+			"branch", branch)
+		branchOpts = append(branchOpts, WithForceDelete())
 	}
 	brOut, err := c.Git.BranchDelete(ctx, branch, branchOpts...)
 	if err != nil {
@@ -367,7 +380,7 @@ func (c *RemoveCommand) Run(ctx context.Context, branch string, cwd string, opts
 
 // removePrunable handles removal of a prunable worktree (directory already deleted).
 // It prunes the stale worktree record and deletes the branch.
-func (c *RemoveCommand) removePrunable(ctx context.Context, branch string, opts RemoveOptions, result RemovedWorktree) (RemovedWorktree, error) {
+func (c *RemoveCommand) removePrunable(ctx context.Context, branch string, opts RemoveOptions, checkResult CheckResult, result RemovedWorktree) (RemovedWorktree, error) {
 	if opts.Check {
 		return result, nil
 	}
@@ -383,16 +396,14 @@ func (c *RemoveCommand) removePrunable(ctx context.Context, branch string, opts 
 
 	// Delete the branch
 	var branchOpts []BranchDeleteOption
-	if opts.Force > WorktreeForceLevelNone {
+	switch {
+	case opts.Force > WorktreeForceLevelNone:
 		branchOpts = append(branchOpts, WithForceDelete())
-	} else {
-		// upstream gone (squash/rebase merge) requires -D since commits differ
-		if gone, err := c.Git.IsBranchUpstreamGone(ctx, branch); err == nil && gone {
-			c.Log.DebugContext(ctx, "prunable: upstream gone, using force delete",
-				"category", LogCategoryRemove,
-				"branch", branch)
-			branchOpts = append(branchOpts, WithForceDelete())
-		}
+	case c.shouldForceDeleteBranch(ctx, branch, checkResult):
+		c.Log.DebugContext(ctx, "prunable: upstream gone, using force delete",
+			"category", LogCategoryRemove,
+			"branch", branch)
+		branchOpts = append(branchOpts, WithForceDelete())
 	}
 	brOut, err := c.Git.BranchDelete(ctx, branch, branchOpts...)
 	if err != nil {
@@ -547,13 +558,24 @@ func (c *RemoveCommand) Check(ctx context.Context, branch string, opts CheckOpti
 				"paths", excludedSymlinks)
 		}
 		result.ChangedFiles = changedFiles
-		if reason := c.checkSkipReason(ctx, wt, opts, changedFiles); reason != "" {
+
+		// Submodule status affects the removal decision only when force is not
+		// elevated. Compute it once here and cache it for Run() to reuse.
+		smStatus := SubmoduleCleanStatusUnknown
+		if opts.Force < WorktreeForceLevelUnclean {
+			if s, err := c.Git.InDir(wtInfo.Path).CheckSubmoduleCleanStatus(ctx); err == nil {
+				smStatus = s
+			}
+		}
+		result.SubmoduleStatus = smStatus
+
+		if reason := c.checkSkipReason(ctx, wt, opts, changedFiles, smStatus); reason != "" {
 			result.CanRemove = false
 			result.SkipReason = reason
 			// Calculate CleanReason for skip candidates (except merge-related skip reasons)
 			isMergeRelated := reason == SkipNotMerged || reason == SkipSameCommit
 			if opts.Target != "" && !isMergeRelated {
-				result.CleanReason = c.getCleanReason(ctx, branch, opts.Target)
+				result.CleanReason = c.getCleanReason(ctx, branch, opts.Target, opts.MergeStatus)
 				// Clear CleanMerged for WIP branches on first-parent lineage.
 				// A branch with no new commits whose HEAD is a direct ancestor
 				// of target via first-parent is WIP, not genuinely merged.
@@ -580,7 +602,7 @@ func (c *RemoveCommand) Check(ctx context.Context, branch string, opts CheckOpti
 	result.CanRemove = true
 	// CleanReason requires a target branch to determine merge status
 	if opts.Target != "" {
-		result.CleanReason = c.getCleanReason(ctx, branch, opts.Target)
+		result.CleanReason = c.getCleanReason(ctx, branch, opts.Target, opts.MergeStatus)
 		if result.CleanReason != "" {
 			c.Log.DebugContext(ctx, "clean reason",
 				"category", LogCategoryRemove,
@@ -593,8 +615,8 @@ func (c *RemoveCommand) Check(ctx context.Context, branch string, opts CheckOpti
 
 // checkSkipReason checks if worktree should be skipped and returns the reason.
 // force level controls which conditions can be bypassed (matches git worktree behavior).
-// changedFiles is pre-fetched to avoid redundant git status calls.
-func (c *RemoveCommand) checkSkipReason(ctx context.Context, wt Worktree, opts CheckOptions, changedFiles []FileStatus) SkipReason {
+// changedFiles and smStatus are pre-fetched to avoid redundant git calls.
+func (c *RemoveCommand) checkSkipReason(ctx context.Context, wt Worktree, opts CheckOptions, changedFiles []FileStatus, smStatus SubmoduleCleanStatus) SkipReason {
 	// Check detached HEAD (never bypassed)
 	if wt.Detached {
 		return SkipDetached
@@ -613,8 +635,7 @@ func (c *RemoveCommand) checkSkipReason(ctx context.Context, wt Worktree, opts C
 
 	// Check dirty submodule and uncommitted changes
 	if opts.Force < WorktreeForceLevelUnclean {
-		smStatus, err := c.Git.InDir(wt.Path).CheckSubmoduleCleanStatus(ctx)
-		if err == nil && smStatus == SubmoduleCleanStatusDirty {
+		if smStatus == SubmoduleCleanStatusDirty {
 			return SkipDirtySubmodule
 		}
 
@@ -635,7 +656,7 @@ func (c *RemoveCommand) checkSkipReason(ctx context.Context, wt Worktree, opts C
 // checkPrunableSkipReason checks if a prunable branch should be skipped.
 // Only checks merged status since worktree-specific conditions don't apply.
 // mergeStatus is pre-fetched to avoid redundant git branch --merged calls.
-func (c *RemoveCommand) checkPrunableSkipReason(ctx context.Context, branch, target string, force WorktreeForceLevel, mergeStatus BranchMergeStatus) SkipReason {
+func (c *RemoveCommand) checkPrunableSkipReason(ctx context.Context, branch, target string, force WorktreeForceLevel, mergeStatus *BranchMergeStatus) SkipReason {
 	// Check merged (only when target is specified)
 	if target != "" && force < WorktreeForceLevelUnclean {
 		return c.checkMergedSkipReason(ctx, branch, target, mergeStatus)
@@ -646,13 +667,9 @@ func (c *RemoveCommand) checkPrunableSkipReason(ctx context.Context, branch, tar
 // checkMergedSkipReason checks if a branch should be skipped due to merge status.
 // Returns appropriate SkipReason: empty if merged, SkipNotMerged if not merged,
 // or a dynamic "same commit as <target>" if pointing to same commit as target.
-func (c *RemoveCommand) checkMergedSkipReason(ctx context.Context, branch, target string, mergeStatus BranchMergeStatus) SkipReason {
-	// Check if we have cached results
-	hasCachedResult := len(mergeStatus.Merged) > 0 || len(mergeStatus.SameCommit) > 0
-
-	if hasCachedResult {
-		// Use cached results
-		if mergeStatus.Merged[branch] {
+func (c *RemoveCommand) checkMergedSkipReason(ctx context.Context, branch, target string, mergeStatus *BranchMergeStatus) SkipReason {
+	if mergeStatus != nil {
+		if mergeStatus.IsMerged(branch) {
 			return "" // merged, can remove
 		}
 		if mergeStatus.SameCommit[branch] {
@@ -670,8 +687,14 @@ func (c *RemoveCommand) checkMergedSkipReason(ctx context.Context, branch, targe
 	return SkipNotMerged
 }
 
-// getCleanReason determines why a branch is cleanable.
-func (c *RemoveCommand) getCleanReason(ctx context.Context, branch, target string) CleanReason {
+// getCleanReason determines why a branch is cleanable. When a pre-fetched
+// mergeStatus is available it is used directly; otherwise git is queried.
+func (c *RemoveCommand) getCleanReason(ctx context.Context, branch, target string, mergeStatus *BranchMergeStatus) CleanReason {
+	if mergeStatus != nil {
+		return mergeStatus.CleanReason(branch)
+	}
+
+	// Fallback: no cache available, query git directly.
 	// Check if branch is merged via traditional merge
 	out, err := c.Git.Run(ctx, GitCmdBranch, "--merged", target, "--format=%(refname:short)")
 	if err == nil {
@@ -689,4 +712,19 @@ func (c *RemoveCommand) getCleanReason(ctx context.Context, branch, target strin
 	}
 
 	return ""
+}
+
+// shouldForceDeleteBranch reports whether deleting the branch needs -D.
+// Upstream-gone branches (squash/rebase merged) diverge from target, so -d
+// would fail. A cached clean reason answers this without a git call; when
+// absent (e.g. a single remove without a target) it falls back to a query.
+func (c *RemoveCommand) shouldForceDeleteBranch(ctx context.Context, branch string, checkResult CheckResult) bool {
+	switch checkResult.CleanReason {
+	case CleanUpstreamGone:
+		return true
+	case CleanMerged:
+		return false
+	}
+	gone, err := c.Git.IsBranchUpstreamGone(ctx, branch)
+	return err == nil && gone
 }

--- a/remove_test.go
+++ b/remove_test.go
@@ -1714,3 +1714,75 @@ func TestRemoveCommand_UpstreamGoneUsesForceDelete(t *testing.T) {
 		})
 	}
 }
+
+// TestRemoveCommand_Run_UsesPreCheckedResult verifies that a pre-fetched check
+// result lets Run skip all eligibility queries, running only the mutating
+// worktree remove and branch delete.
+func TestRemoveCommand_Run_UsesPreCheckedResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cleanReason CleanReason
+		wantDelete  string // "branch -d" or "branch -D"
+	}{
+		{
+			name:        "merged uses plain delete",
+			cleanReason: CleanMerged,
+			wantDelete:  "branch -d",
+		},
+		{
+			name:        "upstream gone uses force delete",
+			cleanReason: CleanUpstreamGone,
+			wantDelete:  "branch -D",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockGit := &testutil.MockGitExecutor{
+				Worktrees: []testutil.MockWorktree{
+					{Path: "/repo/main", Branch: "main"},
+					{Path: "/repo/feat/a", Branch: "feat/a"},
+				},
+			}
+			counter := newCountingExecutor(mockGit)
+
+			cmd := &RemoveCommand{
+				FS:     &testutil.MockFS{},
+				Git:    &GitRunner{Executor: counter, Log: NewNopLogger()},
+				Config: &Config{WorktreeSourceDir: "/repo/main"},
+				Log:    NewNopLogger(),
+			}
+
+			preChecked := &CheckResult{
+				CanRemove:       true,
+				WorktreePath:    "/repo/feat/a",
+				Branch:          "feat/a",
+				CleanReason:     tt.cleanReason,
+				SubmoduleStatus: SubmoduleCleanStatusNone,
+			}
+
+			_, err := cmd.Run(t.Context(), "feat/a", "/other/dir", RemoveOptions{PreChecked: preChecked})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// No eligibility queries are issued when the result is pre-checked.
+			forbidden := []string{"worktree list", "status", "submodule status", "for-each-ref", "rev-parse"}
+			for _, key := range forbidden {
+				if got := counter.counts[key]; got != 0 {
+					t.Errorf("%s called %d times, want 0", key, got)
+				}
+			}
+			if got := counter.counts["worktree remove"]; got != 1 {
+				t.Errorf("worktree remove called %d times, want 1", got)
+			}
+			if got := counter.counts[tt.wantDelete]; got != 1 {
+				t.Errorf("%s called %d times, want 1", tt.wantDelete, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`twig clean` starts many more git subprocesses than the work requires,
which dominates its runtime on repositories with several worktrees.

Two sources of redundancy:

1. **Check phase.** `getCleanReason` ran `git branch --merged` plus a
   `for-each-ref` for every candidate, even though
   `ClassifyBranchMergeStatus` had already fetched exactly that
   information once for the whole command. `BranchMergeStatus` collapsed
   "merged" and "upstream gone" into a single map, so the display reason
   could not be reconstructed from it and had to be re-queried.
2. **Delete phase.** `CleanCommand.Run` passed no results to
   `RemoveCommand.Run`, so `Run` re-ran the entire `Check` from scratch
   for each removal (`worktree list` + `git status` +
   `rev-parse --show-toplevel` + `submodule status` twice +
   a `for-each-ref` for the branch-delete decision) when the only
   mutating work is `worktree remove` and the branch delete.

## Approach

- Extend `BranchMergeStatus` with a `Gone` map and `IsMerged` /
  `CleanReason` helpers, so both the removal safety check and the
  display reason come from the single cached classification.
- Make `CheckOptions.MergeStatus` a `*BranchMergeStatus` so cache
  presence is explicit (previously inferred from map length, which
  silently fell back when no branch was merged).
- Add `RemoveOptions.PreChecked` and `CheckResult.SubmoduleStatus`.
  When clean supplies a pre-checked result, `Run` skips `Check`
  entirely and reuses the cached submodule status.
- Decide `-d` vs `-D` from the cached `CleanReason` (upstream-gone
  needs `-D`) instead of an extra `IsBranchUpstreamGone` call, falling
  back to the query only when no cache is available (single
  `twig remove`).

Behavior is unchanged: output, exit codes, and every safety check
(merged / same-commit / dirty / dirty-submodule / locked / current /
detached / WIP first-parent / `--stale` / `--force`) are preserved.
`--stale` candidates are re-checked with elevated force rather than
reusing a cached result that still records `CanRemove=false`.

## Measurements

Disposable repo: `main` + a merge-commit branch, an upstream-gone
branch, a merged-but-dirty branch (stale), and an unmerged branch,
each with a worktree. git invocations counted from `-vv` output.

| Command                   | before | after | reduction |
|---------------------------|--------|-------|-----------|
| `clean --check` (check)   | 22     | 18    | -18%      |
| `clean --yes` (check+del) | 60     | 40    | -33%      |

The CLI runs `clean --yes` as two passes (analyze, then execute), so
its totals cover two check phases plus the delete phase. Per-command
breakdown for `clean --yes` (before → after):

| git subcommand                     | before | after |
|------------------------------------|--------|-------|
| `branch --merged`                  | 8      | 2     |
| `for-each-ref` (upstream:track)    | 4      | 0     |
| `submodule status`                 | 12     | 8     |
| `status --porcelain`               | 10     | 8     |
| `rev-parse --show-toplevel`        | 10     | 8     |
| `worktree list`                    | 6      | 4     |
| `worktree remove` (actual work)    | 2      | 2     |
| `branch -d` / `-D` (actual work)   | 1 / 1  | 1 / 1 |

The remaining `branch --merged` (2) and classification `for-each-ref`
(2) come from the CLI's two passes, each running one classification;
that is outside this change's scope.

## Testing

- `go test ./...` and `go test -tags=integration ./...` pass.
- `make lint` and `make fmt` are clean.
- New unit tests assert the reduced call counts with a counting
  executor: clean runs `branch --merged` and `for-each-ref` once each
  and reuses submodule status; `Run` with a pre-checked result issues
  only `worktree remove` + the branch delete.
- E2E on the disposable repo confirmed identical `--check` output,
  successful removals, and that `--stale`, `--force`, and single
  `twig remove` (cache-less fallback) still behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
