### PR TITLE
feat(clean): detect squash-merged branches via synthetic commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "twig",
       "description": "Claude Code plugin for twig - simplifies git worktree workflows",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "category": "productivity",
       "keywords": ["git", "worktree", "branch", "cli", "twig"],
       "source": "./external/claude-code/plugins/twig"

--- a/clean_integration_test.go
+++ b/clean_integration_test.go
@@ -1723,3 +1723,169 @@ func TestCleanCommand_Integration(t *testing.T) {
 		}
 	})
 }
+
+func TestCleanCommand_SquashMerged_Integration(t *testing.T) {
+	t.Parallel()
+
+	// setupSquashMerged creates a worktree with one commit and squash merges it
+	// into main, the shape a squash-merged pull request leaves behind when the
+	// remote branch is not deleted.
+	setupSquashMerged := func(t *testing.T, repoDir, mainDir, branch string) string {
+		t.Helper()
+		wtPath := filepath.Join(repoDir, branch)
+		testutil.RunGit(t, mainDir, "worktree", "add", "-b", branch, wtPath)
+		if err := os.WriteFile(filepath.Join(wtPath, "feature.txt"), []byte("one\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		testutil.RunGit(t, wtPath, "add", "feature.txt")
+		testutil.RunGit(t, wtPath, "commit", "-m", "feature work")
+		testutil.RunGit(t, mainDir, "merge", "--squash", branch)
+		testutil.RunGit(t, mainDir, "commit", "-m", "squashed "+branch)
+		return wtPath
+	}
+
+	newCmd := func(t *testing.T, mainDir string) *CleanCommand {
+		t.Helper()
+		cfgResult, err := LoadConfig(mainDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return &CleanCommand{
+			FS:     osFS{},
+			Git:    NewGitRunner(mainDir),
+			Config: cfgResult.Config,
+			Log:    NewNopLogger(),
+		}
+	}
+
+	t.Run("RemovesSquashMergedWorktree", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+		wtPath := setupSquashMerged(t, repoDir, mainDir, "feat/squashed")
+
+		cmd := newCmd(t, mainDir)
+
+		result, err := cmd.Run(t.Context(), mainDir, CleanOptions{Yes: true})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+		if len(result.Candidates) != 1 {
+			t.Fatalf("expected 1 candidate, got %d", len(result.Candidates))
+		}
+		cand := result.Candidates[0]
+		if cand.Skipped {
+			t.Fatalf("squash merged branch should be cleaned, skipped with %q", cand.SkipReason)
+		}
+		if cand.CleanReason != CleanSquashMerged {
+			t.Errorf("clean reason = %q, want %q", cand.CleanReason, CleanSquashMerged)
+		}
+		for _, removed := range result.Removed {
+			if removed.Err != nil {
+				t.Fatalf("removal of %s failed: %v", removed.Branch, removed.Err)
+			}
+		}
+		if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+			t.Errorf("worktree %s should be removed", wtPath)
+		}
+		if out := testutil.RunGit(t, mainDir, "branch", "--list"); strings.Contains(out, "feat/squashed") {
+			t.Errorf("branch should be deleted, still listed: %s", out)
+		}
+	})
+
+	t.Run("DetectsAfterTargetMovedOn", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+		setupSquashMerged(t, repoDir, mainDir, "feat/squashed")
+
+		// The target keeps changing the same file the branch introduced.
+		if err := os.WriteFile(filepath.Join(mainDir, "feature.txt"), []byte("one\ntwo\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		testutil.RunGit(t, mainDir, "add", "feature.txt")
+		testutil.RunGit(t, mainDir, "commit", "-m", "follow-up on main")
+
+		cmd := newCmd(t, mainDir)
+
+		result, err := cmd.Run(t.Context(), mainDir, CleanOptions{Check: true})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+		if len(result.Candidates) != 1 {
+			t.Fatalf("expected 1 candidate, got %d", len(result.Candidates))
+		}
+		cand := result.Candidates[0]
+		if cand.Skipped {
+			t.Fatalf("squash merged branch should be cleaned, skipped with %q", cand.SkipReason)
+		}
+		if cand.CleanReason != CleanSquashMerged {
+			t.Errorf("clean reason = %q, want %q", cand.CleanReason, CleanSquashMerged)
+		}
+	})
+
+	t.Run("CleansSquashMergedWithChangesOnStale", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+		wtPath := setupSquashMerged(t, repoDir, mainDir, "feat/squashed")
+
+		if err := os.WriteFile(filepath.Join(wtPath, "debug.log"), []byte("scratch\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := newCmd(t, mainDir)
+
+		result, err := cmd.Run(t.Context(), mainDir, CleanOptions{Check: true, Stale: true})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+		if len(result.Candidates) != 1 {
+			t.Fatalf("expected 1 candidate, got %d", len(result.Candidates))
+		}
+		cand := result.Candidates[0]
+		if cand.Skipped {
+			t.Fatalf("--stale should clean the branch, skipped with %q", cand.SkipReason)
+		}
+		if cand.CleanReason != CleanSquashMerged {
+			t.Errorf("clean reason = %q, want %q", cand.CleanReason, CleanSquashMerged)
+		}
+	})
+
+	t.Run("KeepsWorkInProgressBranch", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		// A branch with no commits of its own, left dirty by ongoing work.
+		wtPath := filepath.Join(repoDir, "feat/wip")
+		testutil.RunGit(t, mainDir, "worktree", "add", "-b", "feat/wip", wtPath)
+		if err := os.WriteFile(filepath.Join(wtPath, "draft.txt"), []byte("draft\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Move the target ahead so the branch is strictly behind it.
+		if err := os.WriteFile(filepath.Join(mainDir, "main.txt"), []byte("main\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		testutil.RunGit(t, mainDir, "add", "main.txt")
+		testutil.RunGit(t, mainDir, "commit", "-m", "main work")
+
+		cmd := newCmd(t, mainDir)
+
+		result, err := cmd.Run(t.Context(), mainDir, CleanOptions{Check: true, Stale: true})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+		if len(result.Candidates) != 1 {
+			t.Fatalf("expected 1 candidate, got %d", len(result.Candidates))
+		}
+		cand := result.Candidates[0]
+		if !cand.Skipped {
+			t.Error("work-in-progress branch should be kept")
+		}
+		if cand.CleanReason != "" {
+			t.Errorf("clean reason = %q, want empty", cand.CleanReason)
+		}
+	})
+}

--- a/clean_test.go
+++ b/clean_test.go
@@ -191,6 +191,179 @@ func TestCleanCommand_Run_MinimizesGitSpawns(t *testing.T) {
 	})
 }
 
+// TestCleanCommand_Run_SquashMerged verifies that a branch whose content was
+// squashed into the target is cleaned, that a branch without an equivalent in
+// the target is kept, and that the probe runs only for branches the cheap
+// classification leaves undecided.
+func TestCleanCommand_Run_SquashMerged(t *testing.T) {
+	t.Parallel()
+
+	newMock := func() *testutil.MockGitExecutor {
+		return &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main", HEAD: "commit-main"},
+				{Path: "/repo/feat/merged", Branch: "feat/merged", HEAD: "commit-merged"},
+				{Path: "/repo/feat/squashed", Branch: "feat/squashed", HEAD: "commit-squashed"},
+				{Path: "/repo/feat/wip", Branch: "feat/wip", HEAD: "commit-wip"},
+			},
+			MergedBranches: map[string][]string{
+				"main": {"main", "feat/merged"},
+			},
+			SquashMergedBranches: []string{"feat/squashed"},
+		}
+	}
+
+	newCmd := func(exec GitExecutor) *CleanCommand {
+		return &CleanCommand{
+			FS:     &testutil.MockFS{},
+			Git:    &GitRunner{Executor: exec, Log: NewNopLogger()},
+			Config: &Config{WorktreeSourceDir: "/repo/main", DefaultSource: "main"},
+			Log:    NewNopLogger(),
+		}
+	}
+
+	t.Run("detects squash merged branch", func(t *testing.T) {
+		t.Parallel()
+
+		counter := newCountingExecutor(newMock())
+		cmd := newCmd(counter)
+
+		result, err := cmd.Run(t.Context(), "/other/dir", CleanOptions{Check: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		byBranch := make(map[string]CleanCandidate, len(result.Candidates))
+		for _, c := range result.Candidates {
+			byBranch[c.Branch] = c
+		}
+
+		squashed := byBranch["feat/squashed"]
+		if squashed.Skipped {
+			t.Errorf("feat/squashed should be cleanable, skipped with %q", squashed.SkipReason)
+		}
+		if squashed.CleanReason != CleanSquashMerged {
+			t.Errorf("feat/squashed clean reason = %q, want %q", squashed.CleanReason, CleanSquashMerged)
+		}
+
+		wip := byBranch["feat/wip"]
+		if !wip.Skipped {
+			t.Error("feat/wip should be skipped")
+		}
+		if wip.SkipReason != SkipNotMerged {
+			t.Errorf("feat/wip skip reason = %q, want %q", wip.SkipReason, SkipNotMerged)
+		}
+
+		merged := byBranch["feat/merged"]
+		if merged.CleanReason != CleanMerged {
+			t.Errorf("feat/merged clean reason = %q, want %q", merged.CleanReason, CleanMerged)
+		}
+
+		// Only the two branches the pre-fetched classification leaves undecided
+		// are probed; the merged branch is answered without git spawns.
+		if got := counter.counts["merge-base"]; got != 2 {
+			t.Errorf("merge-base called %d times, want 2", got)
+		}
+		if got := counter.counts["commit-tree"]; got != 2 {
+			t.Errorf("commit-tree called %d times, want 2", got)
+		}
+	})
+
+	t.Run("deletes squash merged branch with force", func(t *testing.T) {
+		t.Parallel()
+
+		mock := newMock()
+		counter := newCountingExecutor(mock)
+		cmd := newCmd(counter)
+
+		result, err := cmd.Run(t.Context(), "/other/dir", CleanOptions{Yes: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.CleanableCount() != 2 {
+			t.Fatalf("cleanable count = %d, want 2", result.CleanableCount())
+		}
+		// A squashed branch has no commit in common with the target, so -d
+		// would refuse to delete it.
+		if got := counter.counts["branch -D"]; got != 1 {
+			t.Errorf("branch -D called %d times, want 1", got)
+		}
+		if got := counter.counts["branch -d"]; got != 1 {
+			t.Errorf("branch -d called %d times, want 1", got)
+		}
+	})
+
+	t.Run("skips probe when force bypasses merge check", func(t *testing.T) {
+		t.Parallel()
+
+		counter := newCountingExecutor(newMock())
+		cmd := newCmd(counter)
+
+		if _, err := cmd.Run(t.Context(), "/other/dir", CleanOptions{
+			Check: true,
+			Force: WorktreeForceLevelUnclean,
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := counter.counts["merge-base"]; got != 0 {
+			t.Errorf("merge-base called %d times, want 0", got)
+		}
+	})
+}
+
+// TestCleanCommand_Run_SquashMergedWithChanges verifies that a squash merged
+// branch holding uncommitted changes is reported with its clean reason so
+// --stale can act on it.
+func TestCleanCommand_Run_SquashMergedWithChanges(t *testing.T) {
+	t.Parallel()
+
+	mockGit := &testutil.MockGitExecutor{
+		Worktrees: []testutil.MockWorktree{
+			{Path: "/repo/main", Branch: "main", HEAD: "commit-main"},
+			{Path: "/repo/feat/squashed", Branch: "feat/squashed", HEAD: "commit-squashed"},
+		},
+		MergedBranches: map[string][]string{
+			"main": {"main"},
+		},
+		SquashMergedBranches: []string{"feat/squashed"},
+		StatusOutputMap: map[string]string{
+			"/repo/feat/squashed": " M main.go\n",
+		},
+		// The branch carries its own commits, so it is not on the first-parent
+		// lineage of the target and the WIP protection does not apply.
+		FirstParentAncestors: map[string][]string{
+			"main": {"commit-main"},
+		},
+	}
+
+	cmd := &CleanCommand{
+		FS:     &testutil.MockFS{},
+		Git:    &GitRunner{Executor: mockGit, Log: NewNopLogger()},
+		Config: &Config{WorktreeSourceDir: "/repo/main", DefaultSource: "main"},
+		Log:    NewNopLogger(),
+	}
+
+	result, err := cmd.Run(t.Context(), "/other/dir", CleanOptions{Check: true, Stale: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Candidates) != 1 {
+		t.Fatalf("got %d candidates, want 1", len(result.Candidates))
+	}
+
+	cand := result.Candidates[0]
+	if cand.CleanReason != CleanSquashMerged {
+		t.Errorf("clean reason = %q, want %q", cand.CleanReason, CleanSquashMerged)
+	}
+	if cand.Skipped {
+		t.Errorf("--stale should clean the branch, skipped with %q", cand.SkipReason)
+	}
+	if !cand.StaleOverride {
+		t.Error("stale override should be applied")
+	}
+}
+
 func TestCleanResult_CleanableCount(t *testing.T) {
 	t.Parallel()
 

--- a/docs/reference/commands/clean.md
+++ b/docs/reference/commands/clean.md
@@ -94,12 +94,30 @@ The clean command detects merged branches using:
 
 1. `git branch --merged` - traditional merge commits
 2. Upstream gone status - squash/rebase merges via PR
+3. Patch comparison - squash merges whose branch still exists
 
-**Limitation:** Squash and rebase merge detection relies on
-upstream gone status. If the remote branch is not deleted after
-merging the PR, the branch is reported as "not merged". Enable
-GitHub's "Automatically delete head branches" repository setting
-to ensure remote branches are cleaned up after PR merge.
+Patch comparison runs only for branches the first two methods
+leave undecided. The branch is rebuilt as the single commit a
+squash merge would produce (its tree on top of the merge base with
+the target), and `git rev-list --cherry-pick` then checks whether
+every patch it carries already exists in the target. An empty
+result means the whole branch is contained in the target.
+
+Branches with no commits of their own produce an empty patch,
+which is never treated as contained, so ongoing work is not
+reported as merged.
+
+**Limitation:** Patch comparison needs the merged content to match
+the branch. A squash merge that resolved conflicts, or a branch
+amended after the merge, carries patches the target does not have
+and is reported as "not merged". Detection never reports a branch
+that is only partially contained in the target.
+
+**Limitation:** A rebase merge spreads the branch over several
+commits in the target, so the combined patch matches none of them
+unless the branch holds a single commit. Enable GitHub's
+"Automatically delete head branches" repository setting so rebase
+merged branches are detected through upstream gone status.
 
 **Limitation:** Local-only fast-forward merges are not detected.
 When a branch is fast-forward merged locally (without `--no-ff`),
@@ -112,7 +130,9 @@ worked on.
 | Merge commit (`--no-ff`)                | `git branch --merged` | Yes      |
 | Squash merge (PR)                       | Upstream gone         | Yes      |
 | Rebase merge (PR)                       | Upstream gone         | Yes      |
-| Squash merge (PR, branch not deleted)   | (none)                | No       |
+| Squash merge (PR, branch not deleted)   | Patch comparison      | Yes      |
+| Squash merge (conflicts resolved)       | (none)                | No       |
+| Rebase merge (branch not deleted)       | Patch comparison      | 1 commit |
 | Local fast-forward                      | (none)                | No       |
 
 To clean local fast-forward merged branches, use `--force`:
@@ -261,6 +281,7 @@ Clean reasons:
 |------------------|-------------------------------------------------|
 | `merged`         | Branch is merged to target branch               |
 | `upstream gone`  | Remote tracking branch was deleted              |
+| `squash merged`  | Branch content is squashed into target branch   |
 | `prunable, ...`  | Worktree directory was deleted externally       |
 
 Skip reasons:

--- a/docs/reference/commands/clean.md
+++ b/docs/reference/commands/clean.md
@@ -49,14 +49,14 @@ Any other input aborts the operation without removing anything.
 
 All conditions must pass for a worktree to be cleaned:
 
-| Condition          | Description                                      |
-|--------------------|--------------------------------------------------|
-| Merged             | Branch is merged to target or upstream is gone   |
-| No changes         | No uncommitted changes                           |
-| No dirty submodule | Submodules have no uncommitted changes           |
-| Not locked         | Worktree is not locked                           |
-| Not current        | Not the current directory                        |
-| Not main           | Not the main worktree                            |
+| Condition          | Description                                       |
+|--------------------|---------------------------------------------------|
+| Merged             | Branch is merged, squash merged, or upstream gone |
+| No changes         | No uncommitted changes                            |
+| No dirty submodule | Submodules have no uncommitted changes            |
+| Not locked         | Worktree is not locked                            |
+| Not current        | Not the current directory                         |
+| Not main           | Not the main worktree                             |
 
 Files matching the `symlinks`/`extra_symlinks` patterns (see
 [Configuration](../configuration.md#symlinks)) are excluded from the
@@ -76,9 +76,9 @@ associated with a worktree are detected - regular branches created with
 
 Safety checks for prunable branches:
 
-| Condition | Description                                     |
-|-----------|-------------------------------------------------|
-| Merged    | Branch is merged to target or upstream is gone  |
+| Condition | Description                                       |
+|-----------|---------------------------------------------------|
+| Merged    | Branch is merged, squash merged, or upstream gone |
 
 Other checks (locked, changes, current directory) don't apply since
 the worktree no longer exists.

--- a/external/claude-code/plugins/twig/.claude-plugin/plugin.json
+++ b/external/claude-code/plugins/twig/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "twig",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Claude Code plugin for twig - simplifies git worktree workflows",
   "author": {
     "name": "708u"

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/commands/clean.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/commands/clean.md
@@ -49,14 +49,14 @@ Any other input aborts the operation without removing anything.
 
 All conditions must pass for a worktree to be cleaned:
 
-| Condition          | Description                                      |
-|--------------------|--------------------------------------------------|
-| Merged             | Branch is merged to target or upstream is gone   |
-| No changes         | No uncommitted changes                           |
-| No dirty submodule | Submodules have no uncommitted changes           |
-| Not locked         | Worktree is not locked                           |
-| Not current        | Not the current directory                        |
-| Not main           | Not the main worktree                            |
+| Condition          | Description                                       |
+|--------------------|---------------------------------------------------|
+| Merged             | Branch is merged, squash merged, or upstream gone |
+| No changes         | No uncommitted changes                            |
+| No dirty submodule | Submodules have no uncommitted changes            |
+| Not locked         | Worktree is not locked                            |
+| Not current        | Not the current directory                         |
+| Not main           | Not the main worktree                             |
 
 Files matching the `symlinks`/`extra_symlinks` patterns (see
 [Configuration](../configuration.md#symlinks)) are excluded from the
@@ -76,9 +76,9 @@ associated with a worktree are detected - regular branches created with
 
 Safety checks for prunable branches:
 
-| Condition | Description                                     |
-|-----------|-------------------------------------------------|
-| Merged    | Branch is merged to target or upstream is gone  |
+| Condition | Description                                       |
+|-----------|---------------------------------------------------|
+| Merged    | Branch is merged, squash merged, or upstream gone |
 
 Other checks (locked, changes, current directory) don't apply since
 the worktree no longer exists.
@@ -94,12 +94,30 @@ The clean command detects merged branches using:
 
 1. `git branch --merged` - traditional merge commits
 2. Upstream gone status - squash/rebase merges via PR
+3. Patch comparison - squash merges whose branch still exists
 
-**Limitation:** Squash and rebase merge detection relies on
-upstream gone status. If the remote branch is not deleted after
-merging the PR, the branch is reported as "not merged". Enable
-GitHub's "Automatically delete head branches" repository setting
-to ensure remote branches are cleaned up after PR merge.
+Patch comparison runs only for branches the first two methods
+leave undecided. The branch is rebuilt as the single commit a
+squash merge would produce (its tree on top of the merge base with
+the target), and `git rev-list --cherry-pick` then checks whether
+every patch it carries already exists in the target. An empty
+result means the whole branch is contained in the target.
+
+Branches with no commits of their own produce an empty patch,
+which is never treated as contained, so ongoing work is not
+reported as merged.
+
+**Limitation:** Patch comparison needs the merged content to match
+the branch. A squash merge that resolved conflicts, or a branch
+amended after the merge, carries patches the target does not have
+and is reported as "not merged". Detection never reports a branch
+that is only partially contained in the target.
+
+**Limitation:** A rebase merge spreads the branch over several
+commits in the target, so the combined patch matches none of them
+unless the branch holds a single commit. Enable GitHub's
+"Automatically delete head branches" repository setting so rebase
+merged branches are detected through upstream gone status.
 
 **Limitation:** Local-only fast-forward merges are not detected.
 When a branch is fast-forward merged locally (without `--no-ff`),
@@ -112,7 +130,9 @@ worked on.
 | Merge commit (`--no-ff`)                | `git branch --merged` | Yes      |
 | Squash merge (PR)                       | Upstream gone         | Yes      |
 | Rebase merge (PR)                       | Upstream gone         | Yes      |
-| Squash merge (PR, branch not deleted)   | (none)                | No       |
+| Squash merge (PR, branch not deleted)   | Patch comparison      | Yes      |
+| Squash merge (conflicts resolved)       | (none)                | No       |
+| Rebase merge (branch not deleted)       | Patch comparison      | 1 commit |
 | Local fast-forward                      | (none)                | No       |
 
 To clean local fast-forward merged branches, use `--force`:
@@ -261,6 +281,7 @@ Clean reasons:
 |------------------|-------------------------------------------------|
 | `merged`         | Branch is merged to target branch               |
 | `upstream gone`  | Remote tracking branch was deleted              |
+| `squash merged`  | Branch content is squashed into target branch   |
 | `prunable, ...`  | Worktree directory was deleted externally       |
 
 Skip reasons:

--- a/git.go
+++ b/git.go
@@ -45,6 +45,8 @@ const (
 	GitCmdRevList    = "rev-list"
 	GitCmdCheckout   = "checkout"
 	GitCmdReset      = "reset"
+	GitCmdMergeBase  = "merge-base"
+	GitCmdCommitTree = "commit-tree"
 )
 
 // Git worktree subcommands.
@@ -740,6 +742,45 @@ func (g *GitRunner) ClassifyBranchMergeStatus(ctx context.Context, target string
 	}
 
 	return result, nil
+}
+
+// IsSquashMerged reports whether every change on branch is already contained in
+// target. A squash merge rewrites the branch into a single new commit, so no
+// commit is shared and `git branch --merged` reports nothing; comparing patches
+// instead of commits recovers the relation.
+//
+// The branch is synthesized into the shape a squash merge produces - one commit
+// carrying the branch tree on top of the merge base - and rev-list --cherry-pick
+// drops commits whose patch id already exists on the target side. An empty
+// result means the whole branch is present in target.
+//
+// A branch with no commits of its own yields an empty patch, which carries no
+// patch id and therefore always survives the comparison, so such branches are
+// never reported as merged.
+func (g *GitRunner) IsSquashMerged(ctx context.Context, branch, target string) (bool, error) {
+	mbOut, err := g.Run(ctx, GitCmdMergeBase, target, branch)
+	if err != nil {
+		return false, fmt.Errorf("failed to find merge base: %w", err)
+	}
+	mergeBase := strings.TrimSpace(string(mbOut))
+	if mergeBase == "" {
+		return false, nil
+	}
+
+	synOut, err := g.Run(ctx, GitCmdCommitTree, branch+"^{tree}", "-p", mergeBase, "-m", "twig squash merge probe")
+	if err != nil {
+		return false, fmt.Errorf("failed to build synthetic commit: %w", err)
+	}
+	synthetic := strings.TrimSpace(string(synOut))
+	if synthetic == "" {
+		return false, nil
+	}
+
+	out, err := g.Run(ctx, GitCmdRevList, "--cherry-pick", "--right-only", "--no-merges", "-n1", target+"..."+synthetic)
+	if err != nil {
+		return false, fmt.Errorf("failed to compare patches: %w", err)
+	}
+	return strings.TrimSpace(string(out)) == "", nil
 }
 
 // IsBranchUpstreamGone checks if the branch's upstream tracking branch is gone.

--- a/git_integration_test.go
+++ b/git_integration_test.go
@@ -294,3 +294,124 @@ func TestGitRunner_BranchDelete_Integration(t *testing.T) {
 		}
 	})
 }
+
+func TestGitRunner_IsSquashMerged_Integration(t *testing.T) {
+	t.Parallel()
+
+	// writeCommit commits a file with the given content on the current branch.
+	writeCommit := func(t *testing.T, dir, name, content, message string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		testutil.RunGit(t, dir, "add", name)
+		testutil.RunGit(t, dir, "commit", "-m", message)
+	}
+
+	t.Run("SquashMerged", func(t *testing.T) {
+		t.Parallel()
+
+		_, mainDir := testutil.SetupTestRepo(t, testutil.WithoutSettings())
+
+		testutil.RunGit(t, mainDir, "checkout", "-b", "feat/x")
+		writeCommit(t, mainDir, "feature.txt", "one\n", "first")
+		writeCommit(t, mainDir, "feature.txt", "one\ntwo\n", "second")
+		testutil.RunGit(t, mainDir, "checkout", "main")
+		testutil.RunGit(t, mainDir, "merge", "--squash", "feat/x")
+		testutil.RunGit(t, mainDir, "commit", "-m", "squashed feat/x")
+
+		runner := NewGitRunner(mainDir)
+
+		got, err := runner.IsSquashMerged(t.Context(), "feat/x", "main")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !got {
+			t.Error("squash merged branch should be detected")
+		}
+	})
+
+	t.Run("TargetMovedAfterSquashMerge", func(t *testing.T) {
+		t.Parallel()
+
+		_, mainDir := testutil.SetupTestRepo(t, testutil.WithoutSettings())
+
+		testutil.RunGit(t, mainDir, "checkout", "-b", "feat/x")
+		writeCommit(t, mainDir, "feature.txt", "one\n", "first")
+		testutil.RunGit(t, mainDir, "checkout", "main")
+		testutil.RunGit(t, mainDir, "merge", "--squash", "feat/x")
+		testutil.RunGit(t, mainDir, "commit", "-m", "squashed feat/x")
+		// The target keeps evolving the same file the branch introduced.
+		writeCommit(t, mainDir, "feature.txt", "one\nthree\n", "follow-up on main")
+
+		runner := NewGitRunner(mainDir)
+
+		got, err := runner.IsSquashMerged(t.Context(), "feat/x", "main")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !got {
+			t.Error("squash merged branch should stay detected after target moves on")
+		}
+	})
+
+	t.Run("BranchWithoutOwnCommits", func(t *testing.T) {
+		t.Parallel()
+
+		_, mainDir := testutil.SetupTestRepo(t, testutil.WithoutSettings())
+
+		writeCommit(t, mainDir, "main.txt", "main\n", "main work")
+		testutil.RunGit(t, mainDir, "branch", "feat/wip")
+		writeCommit(t, mainDir, "main.txt", "main\nmore\n", "more main work")
+
+		runner := NewGitRunner(mainDir)
+
+		got, err := runner.IsSquashMerged(t.Context(), "feat/wip", "main")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got {
+			t.Error("branch without its own commits should not be detected as merged")
+		}
+	})
+
+	t.Run("BranchWithUnmergedCommit", func(t *testing.T) {
+		t.Parallel()
+
+		_, mainDir := testutil.SetupTestRepo(t, testutil.WithoutSettings())
+
+		testutil.RunGit(t, mainDir, "checkout", "-b", "feat/x")
+		writeCommit(t, mainDir, "feature.txt", "one\n", "first")
+		testutil.RunGit(t, mainDir, "checkout", "main")
+
+		runner := NewGitRunner(mainDir)
+
+		got, err := runner.IsSquashMerged(t.Context(), "feat/x", "main")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got {
+			t.Error("unmerged branch should not be detected")
+		}
+	})
+
+	t.Run("UnrelatedHistory", func(t *testing.T) {
+		t.Parallel()
+
+		_, mainDir := testutil.SetupTestRepo(t, testutil.WithoutSettings())
+
+		testutil.RunGit(t, mainDir, "checkout", "--orphan", "orphan")
+		testutil.RunGit(t, mainDir, "commit", "--allow-empty", "-m", "orphan root")
+		testutil.RunGit(t, mainDir, "checkout", "main")
+
+		runner := NewGitRunner(mainDir)
+
+		got, err := runner.IsSquashMerged(t.Context(), "orphan", "main")
+		if err == nil {
+			t.Fatal("expected error for branches without a common ancestor")
+		}
+		if got {
+			t.Error("branch without a common ancestor should not be detected")
+		}
+	})
+}

--- a/internal/testutil/mock_git.go
+++ b/internal/testutil/mock_git.go
@@ -142,6 +142,15 @@ type MockGitExecutor struct {
 
 	// ResetErr is returned when reset is called.
 	ResetErr error
+
+	// SquashMergedBranches is a list of branches whose content is fully
+	// contained in the target as a squashed commit.
+	// Used by rev-list --cherry-pick to detect squash merged branches.
+	SquashMergedBranches []string
+
+	// NoMergeBaseBranches is a list of branches that share no history with the
+	// target, making git merge-base fail.
+	NoMergeBaseBranches []string
 }
 
 func (m *MockGitExecutor) Run(ctx context.Context, args ...string) ([]byte, error) {
@@ -193,6 +202,10 @@ func (m *MockGitExecutor) defaultRun(args ...string) ([]byte, error) {
 		return m.handleSubmodule(args)
 	case "rev-list":
 		return m.handleRevList(args)
+	case "merge-base":
+		return m.handleMergeBase(args)
+	case "commit-tree":
+		return m.handleCommitTree(args)
 	case "checkout":
 		return m.handleCheckout(args)
 	case "reset":
@@ -572,11 +585,52 @@ func (m *MockGitExecutor) handleSubmodule(args []string) ([]byte, error) {
 	return nil, nil
 }
 
+// handleMergeBase handles ["merge-base", "<target>", "<branch>"].
+// The returned hash encodes the branch so commit-tree can resolve it back.
+func (m *MockGitExecutor) handleMergeBase(args []string) ([]byte, error) {
+	if len(args) < 3 {
+		return nil, nil
+	}
+	branch := args[2]
+	if slices.Contains(m.NoMergeBaseBranches, branch) {
+		return nil, &MockExitError{Code: 1}
+	}
+	return []byte("mergebase-" + branch + "\n"), nil
+}
+
+// handleCommitTree handles ["commit-tree", "<branch>^{tree}", "-p", ...].
+// The returned hash encodes the branch so rev-list can resolve it back.
+func (m *MockGitExecutor) handleCommitTree(args []string) ([]byte, error) {
+	if len(args) < 2 {
+		return nil, nil
+	}
+	branch := strings.TrimSuffix(args[1], "^{tree}")
+	return []byte("synthetic-" + branch + "\n"), nil
+}
+
 func (m *MockGitExecutor) handleRevList(args []string) ([]byte, error) {
 	// args: ["rev-list", "--first-parent", "<target>"] or
 	// args: ["rev-list", "--first-parent", "<target>", "--not", "<parent>"]
 	if len(args) < 3 {
 		return nil, nil
+	}
+
+	// Squash detection: ["rev-list", "--cherry-pick", "--right-only",
+	// "--no-merges", "-n1", "<target>...synthetic-<branch>"].
+	// An empty result means every patch of the branch is present in target.
+	if slices.Contains(args, "--cherry-pick") {
+		for _, arg := range args[1:] {
+			_, synthetic, found := strings.Cut(arg, "...")
+			if !found {
+				continue
+			}
+			branch := strings.TrimPrefix(synthetic, "synthetic-")
+			if slices.Contains(m.SquashMergedBranches, branch) {
+				return []byte{}, nil
+			}
+			return []byte("unmatched-" + branch + "\n"), nil
+		}
+		return []byte("unmatched\n"), nil
 	}
 
 	// Find the target (first non-flag arg after "rev-list")

--- a/remove.go
+++ b/remove.go
@@ -46,7 +46,51 @@ type CleanReason string
 const (
 	CleanMerged       CleanReason = "merged"
 	CleanUpstreamGone CleanReason = "upstream gone"
+	CleanSquashMerged CleanReason = "squash merged"
 )
+
+// squashMergeProbe answers the squash-merge question for a single branch.
+// The probe costs three git spawns, so it runs on first use and memoizes the
+// answer for the skip decision and the clean reason to share. A nil probe
+// reports no detection, which lets callers disable it by passing nil.
+type squashMergeProbe struct {
+	git    *GitRunner
+	log    *slog.Logger
+	branch string
+	target string
+	done   bool
+	merged bool
+}
+
+func (p *squashMergeProbe) detect(ctx context.Context) bool {
+	if p == nil {
+		return false
+	}
+	if p.done {
+		return p.merged
+	}
+	p.done = true
+
+	merged, err := p.git.IsSquashMerged(ctx, p.branch, p.target)
+	if err != nil {
+		// A history without a common base (orphan branch, unrelated roots)
+		// cannot be compared; keep the branch.
+		p.log.DebugContext(ctx, "squash merge probe failed",
+			"category", LogCategoryRemove,
+			"branch", p.branch,
+			"target", p.target,
+			"error", err.Error())
+		return false
+	}
+	p.merged = merged
+
+	p.log.DebugContext(ctx, "squash merge probe",
+		"category", LogCategoryRemove,
+		"branch", p.branch,
+		"target", p.target,
+		"squashMerged", merged)
+	return merged
+}
 
 // CheckResult holds the result of checking whether a worktree can be removed.
 type CheckResult struct {
@@ -517,6 +561,13 @@ func (c *RemoveCommand) Check(ctx context.Context, branch string, opts CheckOpti
 	result.WorktreePath = wtInfo.Path
 	result.Prunable = wtInfo.Prunable
 
+	// An elevated force level removes the branch regardless of merge status and
+	// deletes it with -D, leaving the probe no decision to influence.
+	var probe *squashMergeProbe
+	if opts.Target != "" && opts.Force < WorktreeForceLevelUnclean {
+		probe = &squashMergeProbe{git: c.Git, log: c.Log, branch: branch, target: opts.Target}
+	}
+
 	c.Log.DebugContext(ctx, "checking",
 		"category", LogCategoryRemove,
 		"branch", branch,
@@ -525,7 +576,7 @@ func (c *RemoveCommand) Check(ctx context.Context, branch string, opts CheckOpti
 
 	if wtInfo.Prunable {
 		// Prunable branch: worktree directory was deleted externally
-		if reason := c.checkPrunableSkipReason(ctx, branch, opts.Target, opts.Force, opts.MergeStatus); reason != "" {
+		if reason := c.checkPrunableSkipReason(ctx, branch, opts.Target, opts.Force, opts.MergeStatus, probe); reason != "" {
 			result.CanRemove = false
 			result.SkipReason = reason
 			c.Log.DebugContext(ctx, "skip",
@@ -570,17 +621,17 @@ func (c *RemoveCommand) Check(ctx context.Context, branch string, opts CheckOpti
 		}
 		result.SubmoduleStatus = smStatus
 
-		if reason := c.checkSkipReason(ctx, wt, opts, changedFiles, smStatus); reason != "" {
+		if reason := c.checkSkipReason(ctx, wt, opts, changedFiles, smStatus, probe); reason != "" {
 			result.CanRemove = false
 			result.SkipReason = reason
 			// Calculate CleanReason for skip candidates (except merge-related skip reasons)
 			isMergeRelated := reason == SkipNotMerged || reason == SkipSameCommit
 			if opts.Target != "" && !isMergeRelated {
-				result.CleanReason = c.getCleanReason(ctx, branch, opts.Target, opts.MergeStatus)
-				// Clear CleanMerged for WIP branches on first-parent lineage.
+				result.CleanReason = c.getCleanReason(ctx, branch, opts.Target, opts.MergeStatus, probe)
+				// Clear the merged reason for WIP branches on first-parent lineage.
 				// A branch with no new commits whose HEAD is a direct ancestor
 				// of target via first-parent is WIP, not genuinely merged.
-				if result.CleanReason == CleanMerged &&
+				if (result.CleanReason == CleanMerged || result.CleanReason == CleanSquashMerged) &&
 					(reason == SkipHasChanges || reason == SkipDirtySubmodule) {
 					isWIP, fpErr := c.Git.IsFirstParentAncestor(
 						ctx, wtInfo.HEAD, opts.Target,
@@ -603,7 +654,7 @@ func (c *RemoveCommand) Check(ctx context.Context, branch string, opts CheckOpti
 	result.CanRemove = true
 	// CleanReason requires a target branch to determine merge status
 	if opts.Target != "" {
-		result.CleanReason = c.getCleanReason(ctx, branch, opts.Target, opts.MergeStatus)
+		result.CleanReason = c.getCleanReason(ctx, branch, opts.Target, opts.MergeStatus, probe)
 		if result.CleanReason != "" {
 			c.Log.DebugContext(ctx, "clean reason",
 				"category", LogCategoryRemove,
@@ -617,7 +668,7 @@ func (c *RemoveCommand) Check(ctx context.Context, branch string, opts CheckOpti
 // checkSkipReason checks if worktree should be skipped and returns the reason.
 // force level controls which conditions can be bypassed (matches git worktree behavior).
 // changedFiles and smStatus are pre-fetched to avoid redundant git calls.
-func (c *RemoveCommand) checkSkipReason(ctx context.Context, wt Worktree, opts CheckOptions, changedFiles []FileStatus, smStatus SubmoduleCleanStatus) SkipReason {
+func (c *RemoveCommand) checkSkipReason(ctx context.Context, wt Worktree, opts CheckOptions, changedFiles []FileStatus, smStatus SubmoduleCleanStatus, probe *squashMergeProbe) SkipReason {
 	// Check detached HEAD (never bypassed)
 	if wt.Detached {
 		return SkipDetached
@@ -657,7 +708,7 @@ func (c *RemoveCommand) checkSkipReason(ctx context.Context, wt Worktree, opts C
 
 	// Check merged (only when target is specified)
 	if opts.Target != "" && opts.Force < WorktreeForceLevelUnclean {
-		return c.checkMergedSkipReason(ctx, wt.Branch, opts.Target, opts.MergeStatus)
+		return c.checkMergedSkipReason(ctx, wt.Branch, opts.Target, opts.MergeStatus, probe)
 	}
 
 	return ""
@@ -666,10 +717,10 @@ func (c *RemoveCommand) checkSkipReason(ctx context.Context, wt Worktree, opts C
 // checkPrunableSkipReason checks if a prunable branch should be skipped.
 // Only checks merged status since worktree-specific conditions don't apply.
 // mergeStatus is pre-fetched to avoid redundant git branch --merged calls.
-func (c *RemoveCommand) checkPrunableSkipReason(ctx context.Context, branch, target string, force WorktreeForceLevel, mergeStatus *BranchMergeStatus) SkipReason {
+func (c *RemoveCommand) checkPrunableSkipReason(ctx context.Context, branch, target string, force WorktreeForceLevel, mergeStatus *BranchMergeStatus, probe *squashMergeProbe) SkipReason {
 	// Check merged (only when target is specified)
 	if target != "" && force < WorktreeForceLevelUnclean {
-		return c.checkMergedSkipReason(ctx, branch, target, mergeStatus)
+		return c.checkMergedSkipReason(ctx, branch, target, mergeStatus, probe)
 	}
 	return ""
 }
@@ -677,13 +728,18 @@ func (c *RemoveCommand) checkPrunableSkipReason(ctx context.Context, branch, tar
 // checkMergedSkipReason checks if a branch should be skipped due to merge status.
 // Returns appropriate SkipReason: empty if merged, SkipNotMerged if not merged,
 // or a dynamic "same commit as <target>" if pointing to same commit as target.
-func (c *RemoveCommand) checkMergedSkipReason(ctx context.Context, branch, target string, mergeStatus *BranchMergeStatus) SkipReason {
+// Branches left undecided by the commit-level signals go to the squash probe,
+// since a squash merge leaves no commit in common with target.
+func (c *RemoveCommand) checkMergedSkipReason(ctx context.Context, branch, target string, mergeStatus *BranchMergeStatus, probe *squashMergeProbe) SkipReason {
 	if mergeStatus != nil {
 		if mergeStatus.IsMerged(branch) {
 			return "" // merged, can remove
 		}
 		if mergeStatus.SameCommit[branch] {
 			return SkipSameCommit
+		}
+		if probe.detect(ctx) {
+			return ""
 		}
 		return SkipNotMerged
 	}
@@ -694,14 +750,23 @@ func (c *RemoveCommand) checkMergedSkipReason(ctx context.Context, branch, targe
 	if err == nil && merged {
 		return ""
 	}
+	if probe.detect(ctx) {
+		return ""
+	}
 	return SkipNotMerged
 }
 
 // getCleanReason determines why a branch is cleanable. When a pre-fetched
 // mergeStatus is available it is used directly; otherwise git is queried.
-func (c *RemoveCommand) getCleanReason(ctx context.Context, branch, target string, mergeStatus *BranchMergeStatus) CleanReason {
+func (c *RemoveCommand) getCleanReason(ctx context.Context, branch, target string, mergeStatus *BranchMergeStatus, probe *squashMergeProbe) CleanReason {
 	if mergeStatus != nil {
-		return mergeStatus.CleanReason(branch)
+		if reason := mergeStatus.CleanReason(branch); reason != "" {
+			return reason
+		}
+		if probe.detect(ctx) {
+			return CleanSquashMerged
+		}
+		return ""
 	}
 
 	// Fallback: no cache available, query git directly.
@@ -721,16 +786,21 @@ func (c *RemoveCommand) getCleanReason(ctx context.Context, branch, target strin
 		return CleanUpstreamGone
 	}
 
+	if probe.detect(ctx) {
+		return CleanSquashMerged
+	}
+
 	return ""
 }
 
 // shouldForceDeleteBranch reports whether deleting the branch needs -D.
-// Upstream-gone branches (squash/rebase merged) diverge from target, so -d
-// would fail. A cached clean reason answers this without a git call; when
-// absent (e.g. a single remove without a target) it falls back to a query.
+// Squash-merged branches, whether detected through a gone upstream or through
+// patch equivalence, diverge from target and would fail -d. A cached clean
+// reason answers this without a git call; when absent (e.g. a single remove
+// without a target) it falls back to a query.
 func (c *RemoveCommand) shouldForceDeleteBranch(ctx context.Context, branch string, checkResult CheckResult) bool {
 	switch checkResult.CleanReason {
-	case CleanUpstreamGone:
+	case CleanUpstreamGone, CleanSquashMerged:
 		return true
 	case CleanMerged:
 		return false


### PR DESCRIPTION
## Overview

`twig clean` detected squash merges only through a gone upstream. When a
repository does not have "Automatically delete head branches" enabled, the
remote branch survives the PR merge and the branch was reported as
`not merged`, so it was never offered as a cleanup candidate.

This adds a third detection method that compares patches instead of commits,
and reports such branches with a distinct `squash merged` reason.

```txt
clean:
  feat/squashed (squash merged)
```

## Detection logic

A squash merge collapses the branch into one new commit, so branch and target
share no commit and `git branch --merged` finds nothing. Rebuilding the branch
in the same shape the squash produced makes the two comparable:

```bash
MB=$(git merge-base <target> <branch>)
SYN=$(git commit-tree "<branch>^{tree}" -p "$MB" -m _)
git rev-list --cherry-pick --right-only --no-merges -n1 <target>..."$SYN"
```

`--cherry-pick` drops commits whose patch id already exists on the other side.
An empty result therefore means every change the branch carries is already in
the target. The same approach is used by
[git-trim](https://github.com/foriequal0/git-trim).

Two properties make this safe as a default:

- Detection confirms the branch is *fully* contained in the target. Anything it
  cannot match errs toward keeping the branch, never toward deleting unmerged
  work.
- A branch with no commits of its own produces an empty patch. Empty patches
  carry no patch id and are never treated as equivalent, so work-in-progress
  branches are not detected.

`git commit-tree` writes a dangling commit object, which git reclaims during
`gc`. Nothing references it and no ref is created.

## Where the probe runs

The probe costs three git subprocesses per branch, so it only runs for branches
that the existing signals leave undecided:

- branches in `git branch --merged`, with a gone upstream, or pointing at the
  target commit are answered from the pre-fetched classification, unchanged
- the result is memoized per branch, shared by the skip decision and the clean
  reason
- `--force` already bypasses the merge check and deletes with `-D`, so no probe
  is created at that force level

This keeps the spawn-count direction of #180 and #181 intact.

Squash-merged branches diverge from the target, so branch deletion uses `-D`,
matching how upstream-gone branches are already handled.

Existing safety behavior is unchanged: `--stale` acts on squash-merged branches
with uncommitted changes, and the first-parent WIP protection still keeps
branches with no new commits. `twig remove` passes no target branch and is
therefore unaffected.

## Limitations

Documented in `docs/reference/commands/clean.md`:

| Case | Detected |
|------|----------|
| Squash merge, branch not deleted | Yes |
| Squash merge with conflicts resolved during merge | No |
| Branch amended after the merge | No |
| Rebase merge, branch not deleted, multiple commits | No |
| Rebase merge, branch not deleted, single commit | Yes |

A rebase merge spreads the branch over several commits in the target, so the
combined patch matches none of them unless the branch holds one commit.

## Verification

- `go test ./...` and `go test -tags=integration ./...` pass
- unit tests (mock-based): detection and clean reason, `-D` on removal, probe
  skipped under `--force`, probe not run for branches already classified,
  `--stale` on a squash-merged branch with uncommitted changes
- integration tests against real repositories: squash merge, squash merge
  followed by further target commits touching the same file, branch with no
  commits of its own, unmerged branch, unrelated history without a merge base,
  end-to-end removal of the worktree and branch, and WIP branch retention
- manual run with a locally built `out/twig`: a squash-merged worktree is listed
  as `(squash merged)` by `twig clean --check` and removed by `twig clean --yes`,
  while a dirty WIP branch is still kept under `--stale`

https://claude.ai/code/session_01SPnVkuzvTEVM8GtByWvqdE
