### PR TITLE
feat(clean): remove merged detached worktrees

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "twig",
       "description": "Claude Code plugin for twig - simplifies git worktree workflows",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "category": "productivity",
       "keywords": ["git", "worktree", "branch", "cli", "twig"],
       "source": "./external/claude-code/plugins/twig"

--- a/clean.go
+++ b/clean.go
@@ -51,12 +51,22 @@ type CleanCandidate struct {
 	Branch        string
 	WorktreePath  string
 	Prunable      bool
+	Detached      bool
 	Skipped       bool
 	SkipReason    SkipReason
 	CleanReason   CleanReason
 	ChangedFiles  []FileStatus
 	StaleOverride bool         // Changes check bypassed via --stale for merged/upstream-gone
 	checkResult   *CheckResult // cached Check result, reused by the removal phase
+}
+
+// DisplayName identifies the candidate in output. A detached worktree has no
+// branch name, so its path stands in.
+func (c CleanCandidate) DisplayName() string {
+	if c.Branch != "" {
+		return c.Branch
+	}
+	return c.WorktreePath
 }
 
 // CleanResult aggregates results from clean operations.
@@ -138,11 +148,15 @@ func (r CleanResult) Format(opts FormatOptions) FormatResult {
 		for i := range r.Removed {
 			if r.Removed[i].Err != nil {
 				fmt.Fprintf(&stderr, "%s %s: %v\n",
-					applyError("error:"), r.Removed[i].Branch, r.Removed[i].Err)
+					applyError("error:"), r.Removed[i].DisplayName(), r.Removed[i].Err)
 				continue
 			}
 			if opts.Verbose {
-				fmt.Fprintf(&stdout, "Removed worktree and branch: %s\n", r.Removed[i].Branch)
+				if r.Removed[i].Detached {
+					fmt.Fprintf(&stdout, "Removed worktree: %s\n", r.Removed[i].WorktreePath)
+				} else {
+					fmt.Fprintf(&stdout, "Removed worktree and branch: %s\n", r.Removed[i].Branch)
+				}
 			}
 		}
 		return FormatResult{Stdout: stdout.String(), Stderr: stderr.String()}
@@ -164,7 +178,7 @@ func (r CleanResult) Format(opts FormatOptions) FormatResult {
 		if opts.Verbose && len(skipped) > 0 {
 			lw.Line(0, "%s", applySkip("skip:"))
 			for _, c := range skipped {
-				lw.Line(1, "%s", c.Branch)
+				lw.Line(1, "%s", c.DisplayName())
 				if c.CleanReason != "" {
 					lw.Line(2, "%s %s", applySuccess("✓"), c.CleanReason)
 				}
@@ -186,13 +200,16 @@ func (r CleanResult) Format(opts FormatOptions) FormatResult {
 	lw.Line(0, "%s", applyClean("clean:"))
 	for _, c := range cleanable {
 		reason := string(c.CleanReason)
+		if c.Detached {
+			reason = "detached, " + reason
+		}
 		if c.Prunable {
 			reason = "prunable, " + reason
 		}
 		if c.StaleOverride {
 			reason += ", stale"
 		}
-		lw.Line(1, "%s %s", c.Branch, applyReason("("+reason+")"))
+		lw.Line(1, "%s %s", c.DisplayName(), applyReason("("+reason+")"))
 	}
 
 	// Output skipped candidates with group header (verbose only)
@@ -200,7 +217,7 @@ func (r CleanResult) Format(opts FormatOptions) FormatResult {
 		fmt.Fprintln(&stdout)
 		lw.Line(0, "%s", applySkip("skip:"))
 		for _, c := range skipped {
-			lw.Line(1, "%s", c.Branch)
+			lw.Line(1, "%s", c.DisplayName())
 			if c.CleanReason != "" {
 				lw.Line(2, "%s %s", applySuccess("✓"), c.CleanReason)
 			}
@@ -304,24 +321,6 @@ func (c *CleanCommand) Run(ctx context.Context, cwd string, opts CleanOptions) (
 			continue
 		}
 
-		// Handle detached HEAD worktrees directly (they have no branch name)
-		if wt.Detached || wt.Branch == "" {
-			c.Log.DebugContext(ctx, "skipping detached worktree",
-				LogAttrKeyCategory.String(), LogCategoryClean,
-				"path", wt.Path)
-			candidates = append(candidates, indexedCandidate{
-				index: candidateIndex,
-				candidate: CleanCandidate{
-					Branch:       wt.Branch,
-					WorktreePath: wt.Path,
-					Skipped:      true,
-					SkipReason:   SkipDetached,
-				},
-			})
-			candidateIndex++
-			continue
-		}
-
 		// Launch parallel check.
 		// Each Check() runs git status which is slow for large repos.
 		// Parallelizing gives ~3x speedup.
@@ -331,20 +330,34 @@ func (c *CleanCommand) Run(ctx context.Context, cwd string, opts CleanOptions) (
 
 			c.Log.DebugContext(ctx, "checking worktree",
 				LogAttrKeyCategory.String(), LogCategoryClean,
-				"branch", wt.Branch)
+				"branch", wt.Branch,
+				"path", wt.Path)
 
-			checkResult, err := removeCmd.Check(ctx, wt.Branch, CheckOptions{
+			checkOpts := CheckOptions{
 				Force:        opts.Force,
 				Target:       target,
 				Cwd:          cwd,
 				CwdRoot:      &cwdRoot,
 				WorktreeInfo: &wt,
 				MergeStatus:  mergeStatus,
-			})
+			}
+
+			// A worktree without a branch cannot be looked up by name, so it
+			// takes the path-keyed check instead.
+			var (
+				checkResult CheckResult
+				err         error
+			)
+			if wt.Detached || wt.Branch == "" {
+				checkResult, err = removeCmd.checkDetached(ctx, wt, checkOpts)
+			} else {
+				checkResult, err = removeCmd.Check(ctx, wt.Branch, checkOpts)
+			}
 			if err != nil {
 				c.Log.DebugContext(ctx, "check failed",
 					LogAttrKeyCategory.String(), LogCategoryClean,
 					"branch", wt.Branch,
+					"path", wt.Path,
 					"error", err.Error())
 				// Skip worktrees that fail to check (e.g., not in any worktree)
 				return
@@ -354,6 +367,7 @@ func (c *CleanCommand) Run(ctx context.Context, cwd string, opts CleanOptions) (
 				Branch:       wt.Branch,
 				WorktreePath: checkResult.WorktreePath,
 				Prunable:     checkResult.Prunable,
+				Detached:     checkResult.Detached,
 				Skipped:      !checkResult.CanRemove,
 				SkipReason:   checkResult.SkipReason,
 				CleanReason:  checkResult.CleanReason,
@@ -364,6 +378,7 @@ func (c *CleanCommand) Run(ctx context.Context, cwd string, opts CleanOptions) (
 			c.Log.DebugContext(ctx, "check completed",
 				LogAttrKeyCategory.String(), LogCategoryClean,
 				"branch", wt.Branch,
+				"path", wt.Path,
 				"canRemove", checkResult.CanRemove,
 				"reason", string(checkResult.CleanReason),
 				"skipReason", string(checkResult.SkipReason))
@@ -439,7 +454,8 @@ func (c *CleanCommand) Run(ctx context.Context, cwd string, opts CleanOptions) (
 
 			c.Log.DebugContext(ctx, "removing worktree",
 				LogAttrKeyCategory.String(), LogCategoryClean,
-				"branch", candidate.Branch)
+				"branch", candidate.Branch,
+				"path", candidate.WorktreePath)
 
 			effectiveForce := opts.Force
 			var preChecked *CheckResult
@@ -462,8 +478,11 @@ func (c *CleanCommand) Run(ctx context.Context, cwd string, opts CleanOptions) (
 				c.Log.DebugContext(ctx, "removal failed",
 					LogAttrKeyCategory.String(), LogCategoryClean,
 					"branch", candidate.Branch,
+					"path", candidate.WorktreePath,
 					"error", err.Error())
 				wt.Branch = candidate.Branch
+				wt.WorktreePath = candidate.WorktreePath
+				wt.Detached = candidate.Detached
 				wt.Err = err
 			}
 

--- a/clean_integration_test.go
+++ b/clean_integration_test.go
@@ -1723,3 +1723,281 @@ func TestCleanCommand_Integration(t *testing.T) {
 		}
 	})
 }
+
+func TestCleanCommand_Integration_DetachedWorktrees(t *testing.T) {
+	t.Parallel()
+
+	// setupDetached prepares a repo whose main branch has an extra commit, then
+	// adds a detached worktree at the given revision.
+	setupDetached := func(t *testing.T, rev string) (mainDir, wtPath string) {
+		t.Helper()
+
+		repoDir, mainDir := testutil.SetupTestRepo(t)
+
+		testFile := filepath.Join(mainDir, "base.txt")
+		if err := os.WriteFile(testFile, []byte("base"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		testutil.RunGit(t, mainDir, "add", "base.txt")
+		testutil.RunGit(t, mainDir, "commit", "-m", "base commit")
+
+		wtPath = filepath.Join(repoDir, "detached")
+		testutil.RunGit(t, mainDir, "worktree", "add", "--detach", wtPath, rev)
+
+		return mainDir, wtPath
+	}
+
+	newCleanCommand := func(t *testing.T, mainDir string) *CleanCommand {
+		t.Helper()
+
+		cfgResult, err := LoadConfig(mainDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return &CleanCommand{
+			FS:     osFS{},
+			Git:    NewGitRunner(mainDir),
+			Config: cfgResult.Config,
+			Log:    NewNopLogger(),
+		}
+	}
+
+	t.Run("CleansDetachedWorktreeContainedInTarget", func(t *testing.T) {
+		t.Parallel()
+
+		mainDir, wtPath := setupDetached(t, "HEAD~1")
+		cmd := newCleanCommand(t, mainDir)
+
+		result, err := cmd.Run(t.Context(), mainDir, CleanOptions{Yes: true})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		if len(result.Candidates) != 1 {
+			t.Fatalf("expected 1 candidate, got %d", len(result.Candidates))
+		}
+		candidate := result.Candidates[0]
+		if candidate.Skipped {
+			t.Fatalf("detached worktree skipped: %s", candidate.SkipReason)
+		}
+		if !candidate.Detached {
+			t.Error("candidate should be marked detached")
+		}
+		if candidate.CleanReason != CleanMerged {
+			t.Errorf("clean reason = %q, want %q", candidate.CleanReason, CleanMerged)
+		}
+		if candidate.WorktreePath != wtPath {
+			t.Errorf("worktree path = %q, want %q", candidate.WorktreePath, wtPath)
+		}
+
+		if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+			t.Errorf("worktree should be removed: %s", wtPath)
+		}
+		if out := testutil.RunGit(t, mainDir, "worktree", "list"); strings.Contains(out, wtPath) {
+			t.Errorf("worktree record should be gone, got: %s", out)
+		}
+
+		// Only main exists; removal must not have deleted any branch.
+		branches := strings.Fields(testutil.RunGit(t, mainDir, "branch", "--format=%(refname:short)"))
+		if len(branches) != 1 || branches[0] != "main" {
+			t.Errorf("branches = %v, want [main]", branches)
+		}
+	})
+
+	t.Run("SkipsDetachedWorktreeWithOwnCommits", func(t *testing.T) {
+		t.Parallel()
+
+		mainDir, wtPath := setupDetached(t, "HEAD")
+
+		// Commit inside the detached worktree so its HEAD leaves main's history.
+		ownFile := filepath.Join(wtPath, "own.txt")
+		if err := os.WriteFile(ownFile, []byte("own"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		testutil.RunGit(t, wtPath, "add", "own.txt")
+		testutil.RunGit(t, wtPath, "commit", "-m", "detached commit")
+
+		cmd := newCleanCommand(t, mainDir)
+		result, err := cmd.Run(t.Context(), mainDir, CleanOptions{Check: true})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		if len(result.Candidates) != 1 {
+			t.Fatalf("expected 1 candidate, got %d", len(result.Candidates))
+		}
+		candidate := result.Candidates[0]
+		if !candidate.Skipped {
+			t.Fatal("detached worktree with unreachable commits should be skipped")
+		}
+		if candidate.SkipReason != SkipNotMerged {
+			t.Errorf("skip reason = %q, want %q", candidate.SkipReason, SkipNotMerged)
+		}
+		if _, err := os.Stat(wtPath); err != nil {
+			t.Errorf("worktree should still exist: %v", err)
+		}
+	})
+
+	t.Run("ForceCleansDetachedWorktreeWithOwnCommits", func(t *testing.T) {
+		t.Parallel()
+
+		mainDir, wtPath := setupDetached(t, "HEAD")
+
+		ownFile := filepath.Join(wtPath, "own.txt")
+		if err := os.WriteFile(ownFile, []byte("own"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		testutil.RunGit(t, wtPath, "add", "own.txt")
+		testutil.RunGit(t, wtPath, "commit", "-m", "detached commit")
+
+		cmd := newCleanCommand(t, mainDir)
+		result, err := cmd.Run(t.Context(), mainDir, CleanOptions{
+			Yes:   true,
+			Force: WorktreeForceLevelUnclean,
+		})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		if len(result.Removed) != 1 {
+			t.Fatalf("expected 1 removed, got %d", len(result.Removed))
+		}
+		if result.Removed[0].Err != nil {
+			t.Fatalf("removal failed: %v", result.Removed[0].Err)
+		}
+		if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+			t.Errorf("worktree should be removed: %s", wtPath)
+		}
+	})
+
+	t.Run("SkipsDetachedWorktreeWithChanges", func(t *testing.T) {
+		t.Parallel()
+
+		mainDir, wtPath := setupDetached(t, "HEAD~1")
+
+		dirtyFile := filepath.Join(wtPath, "base.txt")
+		if err := os.WriteFile(dirtyFile, []byte("modified"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := newCleanCommand(t, mainDir)
+		result, err := cmd.Run(t.Context(), mainDir, CleanOptions{Check: true})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		if len(result.Candidates) != 1 {
+			t.Fatalf("expected 1 candidate, got %d", len(result.Candidates))
+		}
+		if !result.Candidates[0].Skipped {
+			t.Fatal("detached worktree with changes should be skipped")
+		}
+		if result.Candidates[0].SkipReason != SkipHasChanges {
+			t.Errorf("skip reason = %q, want %q", result.Candidates[0].SkipReason, SkipHasChanges)
+		}
+	})
+
+	t.Run("StaleDoesNotOverrideDetachedWithChanges", func(t *testing.T) {
+		t.Parallel()
+
+		mainDir, wtPath := setupDetached(t, "HEAD~1")
+
+		dirtyFile := filepath.Join(wtPath, "base.txt")
+		if err := os.WriteFile(dirtyFile, []byte("modified"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := newCleanCommand(t, mainDir)
+		result, err := cmd.Run(t.Context(), mainDir, CleanOptions{Check: true, Stale: true})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		if len(result.Candidates) != 1 {
+			t.Fatalf("expected 1 candidate, got %d", len(result.Candidates))
+		}
+		candidate := result.Candidates[0]
+		if !candidate.Skipped {
+			t.Fatal("--stale must not bypass uncommitted changes for a detached worktree")
+		}
+		if candidate.StaleOverride {
+			t.Error("stale override should not apply to detached worktrees")
+		}
+		if _, err := os.Stat(wtPath); err != nil {
+			t.Errorf("worktree should still exist: %v", err)
+		}
+	})
+
+	t.Run("SkipsLockedDetachedWorktree", func(t *testing.T) {
+		t.Parallel()
+
+		mainDir, wtPath := setupDetached(t, "HEAD~1")
+		testutil.RunGit(t, mainDir, "worktree", "lock", wtPath)
+
+		cmd := newCleanCommand(t, mainDir)
+		result, err := cmd.Run(t.Context(), mainDir, CleanOptions{Check: true})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		if len(result.Candidates) != 1 {
+			t.Fatalf("expected 1 candidate, got %d", len(result.Candidates))
+		}
+		candidate := result.Candidates[0]
+		if !candidate.Skipped {
+			t.Fatal("locked detached worktree should be skipped")
+		}
+		if candidate.SkipReason != SkipLocked {
+			t.Errorf("skip reason = %q, want %q", candidate.SkipReason, SkipLocked)
+		}
+		// A locked worktree is otherwise removable, so the reason is shown.
+		if candidate.CleanReason != CleanMerged {
+			t.Errorf("clean reason = %q, want %q", candidate.CleanReason, CleanMerged)
+		}
+	})
+
+	t.Run("SkipsCurrentDetachedWorktree", func(t *testing.T) {
+		t.Parallel()
+
+		mainDir, wtPath := setupDetached(t, "HEAD~1")
+
+		cmd := newCleanCommand(t, mainDir)
+		result, err := cmd.Run(t.Context(), wtPath, CleanOptions{Check: true})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		if len(result.Candidates) != 1 {
+			t.Fatalf("expected 1 candidate, got %d", len(result.Candidates))
+		}
+		if result.Candidates[0].SkipReason != SkipCurrentDir {
+			t.Errorf("skip reason = %q, want %q", result.Candidates[0].SkipReason, SkipCurrentDir)
+		}
+	})
+
+	t.Run("PrunesDetachedWorktreeRecordWhenDirectoryDeleted", func(t *testing.T) {
+		t.Parallel()
+
+		mainDir, wtPath := setupDetached(t, "HEAD~1")
+
+		if err := os.RemoveAll(wtPath); err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := newCleanCommand(t, mainDir)
+		result, err := cmd.Run(t.Context(), mainDir, CleanOptions{Yes: true})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+
+		if len(result.Removed) != 1 {
+			t.Fatalf("expected 1 removed, got %d", len(result.Removed))
+		}
+		if result.Removed[0].Err != nil {
+			t.Fatalf("removal failed: %v", result.Removed[0].Err)
+		}
+		if out := testutil.RunGit(t, mainDir, "worktree", "list"); strings.Contains(out, wtPath) {
+			t.Errorf("stale worktree record should be pruned, got: %s", out)
+		}
+	})
+}

--- a/clean_test.go
+++ b/clean_test.go
@@ -2,6 +2,7 @@ package twig
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -524,6 +525,67 @@ func TestCleanResult_Format(t *testing.T) {
 			wantStdout: "clean:\n  feat/a (merged)\n  feat/dirty (merged, stale)\n\nskip:\n  feat/wip\n    ✗ not merged\n",
 			wantStderr: "",
 		},
+		{
+			name: "detached_candidate_shows_path_and_reason",
+			result: CleanResult{
+				Candidates: []CleanCandidate{
+					{WorktreePath: "/repo/detached", Detached: true, Skipped: false, CleanReason: CleanMerged},
+				},
+				Check: true,
+			},
+			opts:       FormatOptions{},
+			wantStdout: "clean:\n  /repo/detached (detached, merged)\n",
+			wantStderr: "",
+		},
+		{
+			name: "detached_prunable_candidate",
+			result: CleanResult{
+				Candidates: []CleanCandidate{
+					{WorktreePath: "/repo/detached", Detached: true, Prunable: true, Skipped: false, CleanReason: CleanMerged},
+				},
+				Check: true,
+			},
+			opts:       FormatOptions{},
+			wantStdout: "clean:\n  /repo/detached (prunable, detached, merged)\n",
+			wantStderr: "",
+		},
+		{
+			name: "detached_skipped_shows_path",
+			result: CleanResult{
+				Candidates: []CleanCandidate{
+					{Branch: "feat/a", Skipped: false, CleanReason: CleanMerged},
+					{WorktreePath: "/repo/detached", Detached: true, Skipped: true, SkipReason: SkipNotMerged},
+				},
+				Check: true,
+			},
+			opts:       FormatOptions{Verbose: true},
+			wantStdout: "clean:\n  feat/a (merged)\n\nskip:\n  /repo/detached\n    ✗ not merged\n",
+			wantStderr: "",
+		},
+		{
+			name: "detached_execution_results_verbose",
+			result: CleanResult{
+				Removed: []RemovedWorktree{
+					{WorktreePath: "/repo/detached", Detached: true},
+				},
+				Check: false,
+			},
+			opts:       FormatOptions{Verbose: true},
+			wantStdout: "Removed worktree: /repo/detached\n",
+			wantStderr: "",
+		},
+		{
+			name: "detached_execution_error_shows_path",
+			result: CleanResult{
+				Removed: []RemovedWorktree{
+					{WorktreePath: "/repo/detached", Detached: true, Err: errors.New("boom")},
+				},
+				Check: false,
+			},
+			opts:       FormatOptions{},
+			wantStdout: "",
+			wantStderr: "error: /repo/detached: boom\n",
+		},
 		// ColorEnabled tests - output should be identical when color disabled
 		{
 			name: "color_disabled_same_as_no_color",
@@ -672,7 +734,7 @@ func TestCleanCommand_Run(t *testing.T) {
 			wantSkipped:    1,
 		},
 		{
-			name: "skips_detached_head",
+			name: "skips_detached_head_not_contained_in_target",
 			cwd:  "/other/dir",
 			opts: CleanOptions{},
 			config: &Config{
@@ -683,7 +745,7 @@ func TestCleanCommand_Run(t *testing.T) {
 				return &testutil.MockGitExecutor{
 					Worktrees: []testutil.MockWorktree{
 						{Path: "/repo/main", Branch: "main"},
-						{Path: "/repo/feat/a", Detached: true},
+						{Path: "/repo/detached", Detached: true, HEAD: "own-commit"},
 					},
 					MergedBranches: map[string][]string{
 						"main": {"main"},
@@ -692,6 +754,103 @@ func TestCleanCommand_Run(t *testing.T) {
 			},
 			wantCandidates: 1,
 			wantSkipped:    1,
+		},
+		{
+			name: "cleans_detached_head_contained_in_target",
+			cwd:  "/other/dir",
+			opts: CleanOptions{},
+			config: &Config{
+				WorktreeSourceDir: "/repo/main",
+				DefaultSource:     "main",
+			},
+			setupGit: func() *testutil.MockGitExecutor {
+				return &testutil.MockGitExecutor{
+					Worktrees: []testutil.MockWorktree{
+						{Path: "/repo/main", Branch: "main"},
+						{Path: "/repo/detached", Detached: true, HEAD: "merged-commit"},
+					},
+					MergedBranches: map[string][]string{
+						"main": {"main"},
+					},
+					Ancestors: map[string][]string{
+						"main": {"merged-commit"},
+					},
+				}
+			},
+			wantCandidates: 1,
+			wantSkipped:    0,
+		},
+		{
+			name: "skips_detached_head_in_current_directory",
+			cwd:  "/repo/detached/subdir",
+			opts: CleanOptions{},
+			config: &Config{
+				WorktreeSourceDir: "/repo/main",
+				DefaultSource:     "main",
+			},
+			setupGit: func() *testutil.MockGitExecutor {
+				return &testutil.MockGitExecutor{
+					Worktrees: []testutil.MockWorktree{
+						{Path: "/repo/main", Branch: "main"},
+						{Path: "/repo/detached", Detached: true, HEAD: "merged-commit"},
+					},
+					MergedBranches: map[string][]string{
+						"main": {"main"},
+					},
+					Ancestors: map[string][]string{
+						"main": {"merged-commit"},
+					},
+				}
+			},
+			wantCandidates: 1,
+			wantSkipped:    1,
+		},
+		{
+			name: "skips_locked_detached_head",
+			cwd:  "/other/dir",
+			opts: CleanOptions{},
+			config: &Config{
+				WorktreeSourceDir: "/repo/main",
+				DefaultSource:     "main",
+			},
+			setupGit: func() *testutil.MockGitExecutor {
+				return &testutil.MockGitExecutor{
+					Worktrees: []testutil.MockWorktree{
+						{Path: "/repo/main", Branch: "main"},
+						{Path: "/repo/detached", Detached: true, HEAD: "merged-commit", Locked: true},
+					},
+					MergedBranches: map[string][]string{
+						"main": {"main"},
+					},
+					Ancestors: map[string][]string{
+						"main": {"merged-commit"},
+					},
+				}
+			},
+			wantCandidates: 1,
+			wantSkipped:    1,
+		},
+		{
+			name: "force_cleans_detached_head_not_contained_in_target",
+			cwd:  "/other/dir",
+			opts: CleanOptions{Force: WorktreeForceLevelUnclean, Check: true},
+			config: &Config{
+				WorktreeSourceDir: "/repo/main",
+				DefaultSource:     "main",
+			},
+			setupGit: func() *testutil.MockGitExecutor {
+				return &testutil.MockGitExecutor{
+					Worktrees: []testutil.MockWorktree{
+						{Path: "/repo/main", Branch: "main"},
+						{Path: "/repo/detached", Detached: true, HEAD: "own-commit"},
+					},
+					MergedBranches: map[string][]string{
+						"main": {"main"},
+					},
+				}
+			},
+			wantCandidates: 1,
+			wantSkipped:    0,
 		},
 		{
 			name: "uses_target_flag",
@@ -1013,6 +1172,136 @@ func TestCleanCommand_Run(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCleanCommand_Run_DetachedWorktrees(t *testing.T) {
+	t.Parallel()
+
+	newCmd := func(mockGit *testutil.MockGitExecutor) *CleanCommand {
+		return &CleanCommand{
+			FS:     &testutil.MockFS{},
+			Git:    &GitRunner{Executor: mockGit, Log: NewNopLogger()},
+			Config: &Config{WorktreeSourceDir: "/repo/main", DefaultSource: "main"},
+			Log:    NewNopLogger(),
+		}
+	}
+
+	t.Run("contained_head_is_cleanable_without_branch", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main"},
+				{Path: "/repo/detached", Detached: true, HEAD: "merged-commit"},
+			},
+			MergedBranches: map[string][]string{"main": {"main"}},
+			Ancestors:      map[string][]string{"main": {"merged-commit"}},
+		}
+
+		result, err := newCmd(mockGit).Run(t.Context(), "/other/dir", CleanOptions{Check: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Candidates) != 1 {
+			t.Fatalf("got %d candidates, want 1", len(result.Candidates))
+		}
+
+		got := result.Candidates[0]
+		if got.Skipped {
+			t.Errorf("candidate skipped with reason %q, want cleanable", got.SkipReason)
+		}
+		if !got.Detached {
+			t.Error("Detached = false, want true")
+		}
+		if got.Branch != "" {
+			t.Errorf("Branch = %q, want empty", got.Branch)
+		}
+		if got.WorktreePath != "/repo/detached" {
+			t.Errorf("WorktreePath = %q, want /repo/detached", got.WorktreePath)
+		}
+		if got.CleanReason != CleanMerged {
+			t.Errorf("CleanReason = %q, want %q", got.CleanReason, CleanMerged)
+		}
+		if got.DisplayName() != "/repo/detached" {
+			t.Errorf("DisplayName() = %q, want /repo/detached", got.DisplayName())
+		}
+	})
+
+	t.Run("stale_does_not_bypass_changes", func(t *testing.T) {
+		t.Parallel()
+
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main"},
+				{Path: "/repo/detached", Detached: true, HEAD: "merged-commit"},
+			},
+			MergedBranches:  map[string][]string{"main": {"main"}},
+			Ancestors:       map[string][]string{"main": {"merged-commit"}},
+			StatusOutputMap: map[string]string{"/repo/detached": " M work.go\n"},
+		}
+
+		result, err := newCmd(mockGit).Run(t.Context(), "/other/dir", CleanOptions{Check: true, Stale: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Candidates) != 1 {
+			t.Fatalf("got %d candidates, want 1", len(result.Candidates))
+		}
+
+		got := result.Candidates[0]
+		if !got.Skipped {
+			t.Fatal("candidate is cleanable, want skipped: uncommitted work is all a detached worktree holds")
+		}
+		if got.SkipReason != SkipHasChanges {
+			t.Errorf("SkipReason = %q, want %q", got.SkipReason, SkipHasChanges)
+		}
+		if got.CleanReason != "" {
+			t.Errorf("CleanReason = %q, want empty so --stale cannot override", got.CleanReason)
+		}
+	})
+
+	t.Run("removal_skips_branch_delete", func(t *testing.T) {
+		t.Parallel()
+
+		var captured []string
+		mockGit := &testutil.MockGitExecutor{
+			Worktrees: []testutil.MockWorktree{
+				{Path: "/repo/main", Branch: "main"},
+				{Path: "/repo/detached", Detached: true, HEAD: "merged-commit"},
+			},
+			MergedBranches: map[string][]string{"main": {"main"}},
+			Ancestors:      map[string][]string{"main": {"merged-commit"}},
+			CapturedArgs:   &captured,
+		}
+
+		result, err := newCmd(mockGit).Run(t.Context(), "/other/dir", CleanOptions{Yes: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Removed) != 1 {
+			t.Fatalf("got %d removed, want 1", len(result.Removed))
+		}
+		if result.Removed[0].Err != nil {
+			t.Fatalf("removal failed: %v", result.Removed[0].Err)
+		}
+		if !result.Removed[0].Detached {
+			t.Error("Removed[0].Detached = false, want true")
+		}
+
+		var removedPath string
+		for i, arg := range captured {
+			if arg == "remove" && i+1 < len(captured) {
+				removedPath = captured[i+1]
+			}
+			if arg == "branch" && i+1 < len(captured) &&
+				(captured[i+1] == "-d" || captured[i+1] == "-D") {
+				t.Errorf("branch delete was called for a detached worktree: %v", captured)
+			}
+		}
+		if removedPath != "/repo/detached" {
+			t.Errorf("removed path = %q, want /repo/detached", removedPath)
+		}
+	})
 }
 
 func TestCleanCommand_ResolveTarget(t *testing.T) {

--- a/cmd/twig/main.go
+++ b/cmd/twig/main.go
@@ -443,7 +443,7 @@ Use --yes to skip confirmation and remove immediately.
 Use --check to only show candidates without prompting.
 
 Safety checks (all must pass):
-  - Branch is merged to target
+  - Branch is merged to target (detached HEAD: contained in target)
   - No uncommitted changes
   - Worktree is not locked
   - Not the current directory

--- a/docs/reference/commands/clean.md
+++ b/docs/reference/commands/clean.md
@@ -63,6 +63,44 @@ Files matching the `symlinks`/`extra_symlinks` patterns (see
 "No changes" check, since they are twig-managed symlinks rather than
 genuine changes.
 
+### Detached HEAD Worktrees
+
+A worktree with a detached HEAD has no branch, so the "Merged" check
+cannot apply to it. It is replaced by a reachability test: the worktree
+is cleanable when its HEAD is contained in the target branch
+(`git merge-base --is-ancestor <HEAD> <target>`). All other safety
+checks are unchanged, and no branch is deleted on removal.
+
+Removing such a worktree drops no ref, so nothing is lost: every commit
+it held is still reachable from the target. A detached HEAD that is not
+contained in the target may hold commits nothing else references, so it
+is skipped as "not merged".
+
+Detached worktrees are shown by path, since they have no branch name:
+
+```txt
+clean:
+  /path/to/worktree/experiment (detached, merged)
+
+skip:
+  /path/to/worktree/spike
+    ✗ not merged
+```
+
+Removal reports the path as well:
+
+```txt
+Removed worktree: /path/to/worktree/experiment
+```
+
+Unlike the branch checks, this test accepts commits reachable through
+any parent of a merge. That is sound only because no ref is deleted, so
+it is never used to decide branch removal.
+
+`--stale` does not apply to detached worktrees. Uncommitted changes are
+the only work such a worktree can hold, which makes it the equivalent of
+a WIP branch (see [Stale Option](#stale-option)).
+
 ### Prunable Branches
 
 When a worktree directory is deleted externally (via `rm -rf` or other means),
@@ -115,6 +153,10 @@ worked on.
 | Squash merge (PR, branch not deleted)   | (none)                | No       |
 | Local fast-forward                      | (none)                | No       |
 
+Worktrees with a detached HEAD are exempt from this table: they use the
+reachability test described in
+[Detached HEAD Worktrees](#detached-head-worktrees).
+
 To clean local fast-forward merged branches, use `--force`:
 
 ```bash
@@ -133,10 +175,14 @@ With `--force` (`-f`), some safety checks can be bypassed:
 The following conditions are never bypassed:
 
 - Current directory (dangerous to remove cwd)
-- Detached HEAD (RemoveCommand requires branch name)
 
 This matches `twig remove` behavior where `-f` removes unclean worktrees
 and `-ff` also removes locked worktrees.
+
+`-f` bypasses the reachability test for detached worktrees the same way
+it bypasses "not merged" for branches, so it removes every detached
+worktree that passes the remaining checks, including those holding
+commits reachable from nothing else.
 
 ```bash
 # Force clean unmerged branches with uncommitted changes
@@ -158,10 +204,15 @@ direct ancestor of target via first-parent lineage) are treated as
 work-in-progress even if `git branch --merged` reports them as
 merged. `--stale` does not remove these branches.
 
+**Detached worktree protection:** a detached HEAD contained in the
+target has no commits of its own, so uncommitted changes are the only
+work it can hold. `--stale` treats it like a WIP branch and keeps it.
+
 | Condition            | `--stale` | `--force` |
 |----------------------|-----------|-----------|
 | Changes (merged)     | Bypassed  | Bypassed  |
 | Changes (WIP)        | Kept      | Bypassed  |
+| Changes (detached)   | Kept      | Bypassed  |
 | Dirty submod (merged)| Bypassed  | Bypassed  |
 | Dirty submod (WIP)   | Kept      | Bypassed  |
 | Changes (not merged) | Kept      | Bypassed  |
@@ -223,6 +274,7 @@ clean:
   feat/old-branch (merged)
   fix/completed (upstream gone)
   feat/stale-branch (prunable, merged)
+  /path/to/worktree/experiment (detached, merged)
 
 skip:
   feat/wip
@@ -235,11 +287,14 @@ skip:
   feat/submod
     ✓ merged
     ✗ submodule has uncommitted changes
+  /path/to/worktree/spike
+    ✗ not merged
 ```
 
 - `clean:` shows worktrees and prunable branches that will be removed
 - `skip:` shows skipped worktrees (verbose mode only)
 - Each item is indented with 2 spaces
+- Detached worktrees are identified by path, all others by branch name
 - Skip candidates show both cleanable reason (`✓`) and skip reason (`✗`)
 - A blank line separates groups
 
@@ -262,18 +317,18 @@ Clean reasons:
 | `merged`         | Branch is merged to target branch               |
 | `upstream gone`  | Remote tracking branch was deleted              |
 | `prunable, ...`  | Worktree directory was deleted externally       |
+| `detached, ...`  | Worktree has no branch; HEAD is in target       |
 
 Skip reasons:
 
 | Reason                      | Description                                     |
 |-----------------------------|-------------------------------------------------|
-| `not merged`                | Branch has commits not in target branch         |
+| `not merged`                | Has commits not in the target branch            |
 | `same commit as <target>`   | Branch points to same commit as target          |
 | `has uncommitted changes`   | Worktree has modified or untracked files        |
 | `submodule has uncommitted changes` | Submodule has modified or untracked files |
 | `locked`                    | Worktree is locked                              |
 | `current directory`         | Cannot remove current working directory         |
-| `detached HEAD`             | Worktree has detached HEAD (no branch)          |
 
 ### Debug Output
 
@@ -337,6 +392,15 @@ twig clean --check
 clean:
   feature/old-branch (merged)
   feature/deleted-worktree (prunable, merged)
+
+# Clean with detached HEAD worktrees
+twig clean --check -v
+clean:
+  /repo-worktree/experiment (detached, merged)
+
+skip:
+  /repo-worktree/spike
+    ✗ not merged
 ```
 
 ## Exit Code

--- a/external/claude-code/plugins/twig/.claude-plugin/plugin.json
+++ b/external/claude-code/plugins/twig/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "twig",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Claude Code plugin for twig - simplifies git worktree workflows",
   "author": {
     "name": "708u"

--- a/external/claude-code/plugins/twig/skills/twig-guide/references/commands/clean.md
+++ b/external/claude-code/plugins/twig/skills/twig-guide/references/commands/clean.md
@@ -63,6 +63,44 @@ Files matching the `symlinks`/`extra_symlinks` patterns (see
 "No changes" check, since they are twig-managed symlinks rather than
 genuine changes.
 
+### Detached HEAD Worktrees
+
+A worktree with a detached HEAD has no branch, so the "Merged" check
+cannot apply to it. It is replaced by a reachability test: the worktree
+is cleanable when its HEAD is contained in the target branch
+(`git merge-base --is-ancestor <HEAD> <target>`). All other safety
+checks are unchanged, and no branch is deleted on removal.
+
+Removing such a worktree drops no ref, so nothing is lost: every commit
+it held is still reachable from the target. A detached HEAD that is not
+contained in the target may hold commits nothing else references, so it
+is skipped as "not merged".
+
+Detached worktrees are shown by path, since they have no branch name:
+
+```txt
+clean:
+  /path/to/worktree/experiment (detached, merged)
+
+skip:
+  /path/to/worktree/spike
+    ✗ not merged
+```
+
+Removal reports the path as well:
+
+```txt
+Removed worktree: /path/to/worktree/experiment
+```
+
+Unlike the branch checks, this test accepts commits reachable through
+any parent of a merge. That is sound only because no ref is deleted, so
+it is never used to decide branch removal.
+
+`--stale` does not apply to detached worktrees. Uncommitted changes are
+the only work such a worktree can hold, which makes it the equivalent of
+a WIP branch (see [Stale Option](#stale-option)).
+
 ### Prunable Branches
 
 When a worktree directory is deleted externally (via `rm -rf` or other means),
@@ -115,6 +153,10 @@ worked on.
 | Squash merge (PR, branch not deleted)   | (none)                | No       |
 | Local fast-forward                      | (none)                | No       |
 
+Worktrees with a detached HEAD are exempt from this table: they use the
+reachability test described in
+[Detached HEAD Worktrees](#detached-head-worktrees).
+
 To clean local fast-forward merged branches, use `--force`:
 
 ```bash
@@ -133,10 +175,14 @@ With `--force` (`-f`), some safety checks can be bypassed:
 The following conditions are never bypassed:
 
 - Current directory (dangerous to remove cwd)
-- Detached HEAD (RemoveCommand requires branch name)
 
 This matches `twig remove` behavior where `-f` removes unclean worktrees
 and `-ff` also removes locked worktrees.
+
+`-f` bypasses the reachability test for detached worktrees the same way
+it bypasses "not merged" for branches, so it removes every detached
+worktree that passes the remaining checks, including those holding
+commits reachable from nothing else.
 
 ```bash
 # Force clean unmerged branches with uncommitted changes
@@ -158,10 +204,15 @@ direct ancestor of target via first-parent lineage) are treated as
 work-in-progress even if `git branch --merged` reports them as
 merged. `--stale` does not remove these branches.
 
+**Detached worktree protection:** a detached HEAD contained in the
+target has no commits of its own, so uncommitted changes are the only
+work it can hold. `--stale` treats it like a WIP branch and keeps it.
+
 | Condition            | `--stale` | `--force` |
 |----------------------|-----------|-----------|
 | Changes (merged)     | Bypassed  | Bypassed  |
 | Changes (WIP)        | Kept      | Bypassed  |
+| Changes (detached)   | Kept      | Bypassed  |
 | Dirty submod (merged)| Bypassed  | Bypassed  |
 | Dirty submod (WIP)   | Kept      | Bypassed  |
 | Changes (not merged) | Kept      | Bypassed  |
@@ -223,6 +274,7 @@ clean:
   feat/old-branch (merged)
   fix/completed (upstream gone)
   feat/stale-branch (prunable, merged)
+  /path/to/worktree/experiment (detached, merged)
 
 skip:
   feat/wip
@@ -235,11 +287,14 @@ skip:
   feat/submod
     ✓ merged
     ✗ submodule has uncommitted changes
+  /path/to/worktree/spike
+    ✗ not merged
 ```
 
 - `clean:` shows worktrees and prunable branches that will be removed
 - `skip:` shows skipped worktrees (verbose mode only)
 - Each item is indented with 2 spaces
+- Detached worktrees are identified by path, all others by branch name
 - Skip candidates show both cleanable reason (`✓`) and skip reason (`✗`)
 - A blank line separates groups
 
@@ -262,18 +317,18 @@ Clean reasons:
 | `merged`         | Branch is merged to target branch               |
 | `upstream gone`  | Remote tracking branch was deleted              |
 | `prunable, ...`  | Worktree directory was deleted externally       |
+| `detached, ...`  | Worktree has no branch; HEAD is in target       |
 
 Skip reasons:
 
 | Reason                      | Description                                     |
 |-----------------------------|-------------------------------------------------|
-| `not merged`                | Branch has commits not in target branch         |
+| `not merged`                | Has commits not in the target branch            |
 | `same commit as <target>`   | Branch points to same commit as target          |
 | `has uncommitted changes`   | Worktree has modified or untracked files        |
 | `submodule has uncommitted changes` | Submodule has modified or untracked files |
 | `locked`                    | Worktree is locked                              |
 | `current directory`         | Cannot remove current working directory         |
-| `detached HEAD`             | Worktree has detached HEAD (no branch)          |
 
 ### Debug Output
 
@@ -337,6 +392,15 @@ twig clean --check
 clean:
   feature/old-branch (merged)
   feature/deleted-worktree (prunable, merged)
+
+# Clean with detached HEAD worktrees
+twig clean --check -v
+clean:
+  /repo-worktree/experiment (detached, merged)
+
+skip:
+  /repo-worktree/spike
+    ✗ not merged
 ```
 
 ## Exit Code

--- a/git.go
+++ b/git.go
@@ -45,6 +45,7 @@ const (
 	GitCmdRevList    = "rev-list"
 	GitCmdCheckout   = "checkout"
 	GitCmdReset      = "reset"
+	GitCmdMergeBase  = "merge-base"
 )
 
 // Git worktree subcommands.
@@ -1003,6 +1004,25 @@ func (g *GitRunner) MainWorktreePath(ctx context.Context) (string, error) {
 	}
 	gitDir := strings.TrimSpace(string(out))
 	return filepath.Dir(gitDir), nil
+}
+
+// IsAncestor reports whether commit is reachable from target, including
+// reachability through the second parent of a merge commit.
+//
+// Reachability alone says nothing about whether a branch's work landed on
+// target, so this must not gate branch deletion; IsFirstParentAncestor exists
+// for that. It answers a narrower question: whether removing a ref-less
+// worktree can strand commits.
+func (g *GitRunner) IsAncestor(ctx context.Context, commit, target string) (bool, error) {
+	if _, err := g.Run(ctx, GitCmdMergeBase, "--is-ancestor", commit, target); err != nil {
+		// git reports "not an ancestor" as exit 1; other codes are real failures
+		var exitErr interface{ ExitCode() int }
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check ancestry: %w", err)
+	}
+	return true, nil
 }
 
 // IsFirstParentAncestor checks if commit is on the first-parent lineage of target.

--- a/git_test.go
+++ b/git_test.go
@@ -1,6 +1,7 @@
 package twig
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -172,6 +173,73 @@ func TestGitRunner_IsBranchUpstreamGone(t *testing.T) {
 				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGitRunner_IsAncestor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		commit    string
+		target    string
+		ancestors map[string][]string
+		want      bool
+	}{
+		{
+			name:      "reachable from target",
+			commit:    "commit-abc",
+			target:    "main",
+			ancestors: map[string][]string{"main": {"commit-abc", "commit-def"}},
+			want:      true,
+		},
+		{
+			name:      "not reachable from target",
+			commit:    "commit-xyz",
+			target:    "main",
+			ancestors: map[string][]string{"main": {"commit-abc"}},
+			want:      false,
+		},
+		{
+			name:   "unknown target",
+			commit: "commit-abc",
+			target: "develop",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockGit := &testutil.MockGitExecutor{Ancestors: tt.ancestors}
+			runner := &GitRunner{Executor: mockGit, Log: NewNopLogger()}
+
+			got, err := runner.IsAncestor(t.Context(), tt.commit, tt.target)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGitRunner_IsAncestor_PropagatesFailure(t *testing.T) {
+	t.Parallel()
+
+	// exit 1 is git's "not an ancestor" answer; any other code is a failure
+	// that must not be reported as a clean negative.
+	mockGit := &testutil.MockGitExecutor{
+		RunFunc: func(ctx context.Context, args ...string) ([]byte, error) {
+			return nil, &testutil.MockExitError{Code: 128}
+		},
+	}
+	runner := &GitRunner{Executor: mockGit, Log: NewNopLogger()}
+
+	if _, err := runner.IsAncestor(t.Context(), "bad-object", "main"); err == nil {
+		t.Fatal("expected error for exit code 128, got nil")
 	}
 }
 

--- a/internal/testutil/mock_git.go
+++ b/internal/testutil/mock_git.go
@@ -129,6 +129,11 @@ type MockGitExecutor struct {
 	// RootCommits is a list of commits that have no parent (root commits).
 	RootCommits []string
 
+	// Ancestors maps a ref to the commits reachable from it.
+	// Used by merge-base --is-ancestor. Commits not listed are reported as
+	// non-ancestors, so ancestry must be declared explicitly.
+	Ancestors map[string][]string
+
 	// GitDirMap maps worktree directory to its git directory path.
 	// Used by rev-parse --git-dir.
 	GitDirMap map[string]string
@@ -193,6 +198,8 @@ func (m *MockGitExecutor) defaultRun(args ...string) ([]byte, error) {
 		return m.handleSubmodule(args)
 	case "rev-list":
 		return m.handleRevList(args)
+	case "merge-base":
+		return m.handleMergeBase(args)
 	case "checkout":
 		return m.handleCheckout(args)
 	case "reset":
@@ -597,6 +604,18 @@ func (m *MockGitExecutor) handleRevList(args []string) ([]byte, error) {
 		return []byte{}, nil
 	}
 	return []byte(strings.Join(commits, "\n") + "\n"), nil
+}
+
+func (m *MockGitExecutor) handleMergeBase(args []string) ([]byte, error) {
+	// args: ["merge-base", "--is-ancestor", "<commit>", "<target>"]
+	if len(args) < 4 || args[1] != "--is-ancestor" {
+		return nil, nil
+	}
+	commit, target := args[2], args[3]
+	if slices.Contains(m.Ancestors[target], commit) {
+		return nil, nil
+	}
+	return nil, &MockExitError{Code: 1}
 }
 
 func (m *MockGitExecutor) handleCheckout(args []string) ([]byte, error) {

--- a/remove.go
+++ b/remove.go
@@ -54,6 +54,7 @@ type CheckResult struct {
 	SkipReason      SkipReason           // Reason if cannot be removed
 	CleanReason     CleanReason          // Reason if can be removed (for clean command display)
 	Prunable        bool                 // Whether worktree is prunable (directory was deleted externally)
+	Detached        bool                 // Whether worktree has detached HEAD (no branch to delete)
 	WorktreePath    string               // Path to the worktree
 	Branch          string               // Branch name
 	ChangedFiles    []FileStatus         // Uncommitted changes (for verbose output)
@@ -111,12 +112,22 @@ type RemovedWorktree struct {
 	WorktreePath string
 	CleanedDirs  []string     // Empty parent directories that were removed
 	Pruned       bool         // Stale worktree record was pruned (directory was already deleted)
+	Detached     bool         // Worktree had detached HEAD (no branch was deleted)
 	Check        bool         // --check mode: show what would be removed
 	CanRemove    bool         // Whether the worktree can be removed (from Check)
 	SkipReason   SkipReason   // Reason if cannot be removed (from Check)
 	ChangedFiles []FileStatus // Uncommitted changes (for verbose output)
 	GitOutput    []byte
 	Err          error // nil if success
+}
+
+// DisplayName identifies the worktree in output. A detached worktree has no
+// branch name, so its path stands in.
+func (r RemovedWorktree) DisplayName() string {
+	if r.Branch != "" {
+		return r.Branch
+	}
+	return r.WorktreePath
 }
 
 // RemoveResult aggregates results from remove operations.
@@ -152,7 +163,7 @@ func (r RemoveResult) Format(opts FormatOptions) FormatResult {
 	for i := range r.Removed {
 		wt := &r.Removed[i]
 		if wt.Err != nil {
-			formatRemoveError(&stderr, wt.Branch, wt.Err, opts.Verbose, wt.ChangedFiles)
+			formatRemoveError(&stderr, wt.DisplayName(), wt.Err, opts.Verbose, wt.ChangedFiles)
 			continue
 		}
 		formatted := wt.Format(opts)
@@ -230,7 +241,9 @@ func (r RemovedWorktree) Format(opts FormatOptions) FormatResult {
 				fmt.Fprintf(&stdout, "  %s %s\n", f.Status, f.Path)
 			}
 		}
-		fmt.Fprintf(&stdout, "Would delete branch: %s\n", r.Branch)
+		if !r.Detached {
+			fmt.Fprintf(&stdout, "Would delete branch: %s\n", r.Branch)
+		}
 		for _, dir := range r.CleanedDirs {
 			fmt.Fprintf(&stdout, "Would remove empty directory: %s\n", dir)
 		}
@@ -241,9 +254,14 @@ func (r RemovedWorktree) Format(opts FormatOptions) FormatResult {
 		if len(r.GitOutput) > 0 {
 			stdout.Write(r.GitOutput)
 		}
-		if r.Pruned {
+		switch {
+		case r.Detached && r.Pruned:
+			fmt.Fprintf(&stdout, "Pruned stale worktree: %s\n", r.WorktreePath)
+		case r.Detached:
+			fmt.Fprintf(&stdout, "Removed worktree: %s\n", r.WorktreePath)
+		case r.Pruned:
 			fmt.Fprintf(&stdout, "Pruned stale worktree and deleted branch: %s\n", r.Branch)
-		} else {
+		default:
 			fmt.Fprintf(&stdout, "Removed worktree and branch: %s\n", r.Branch)
 		}
 		for _, dir := range r.CleanedDirs {
@@ -287,6 +305,7 @@ func (c *RemoveCommand) Run(ctx context.Context, branch string, cwd string, opts
 	// Copy check results
 	result.WorktreePath = checkResult.WorktreePath
 	result.Pruned = checkResult.Prunable
+	result.Detached = checkResult.Detached
 	result.CanRemove = checkResult.CanRemove
 	result.SkipReason = checkResult.SkipReason
 	result.ChangedFiles = checkResult.ChangedFiles
@@ -354,21 +373,24 @@ func (c *RemoveCommand) Run(ctx context.Context, branch string, cwd string, opts
 			"branch", branch)
 	}
 
-	var branchOpts []BranchDeleteOption
-	switch {
-	case opts.Force > WorktreeForceLevelNone:
-		branchOpts = append(branchOpts, WithForceDelete())
-	case c.shouldForceDeleteBranch(ctx, branch, checkResult):
-		c.Log.DebugContext(ctx, "upstream gone, using force delete",
-			"category", LogCategoryRemove,
-			"branch", branch)
-		branchOpts = append(branchOpts, WithForceDelete())
+	// A detached worktree holds no branch, so the removal ends here.
+	if !checkResult.Detached {
+		var branchOpts []BranchDeleteOption
+		switch {
+		case opts.Force > WorktreeForceLevelNone:
+			branchOpts = append(branchOpts, WithForceDelete())
+		case c.shouldForceDeleteBranch(ctx, branch, checkResult):
+			c.Log.DebugContext(ctx, "upstream gone, using force delete",
+				"category", LogCategoryRemove,
+				"branch", branch)
+			branchOpts = append(branchOpts, WithForceDelete())
+		}
+		brOut, err := c.Git.BranchDelete(ctx, branch, branchOpts...)
+		if err != nil {
+			return result, err
+		}
+		gitOutput = append(gitOutput, brOut...)
 	}
-	brOut, err := c.Git.BranchDelete(ctx, branch, branchOpts...)
-	if err != nil {
-		return result, err
-	}
-	gitOutput = append(gitOutput, brOut...)
 
 	result.GitOutput = gitOutput
 
@@ -380,7 +402,7 @@ func (c *RemoveCommand) Run(ctx context.Context, branch string, cwd string, opts
 }
 
 // removePrunable handles removal of a prunable worktree (directory already deleted).
-// It prunes the stale worktree record and deletes the branch.
+// It prunes the stale worktree record and deletes the branch, if there is one.
 func (c *RemoveCommand) removePrunable(ctx context.Context, branch string, opts RemoveOptions, checkResult CheckResult, result RemovedWorktree) (RemovedWorktree, error) {
 	if opts.Check {
 		return result, nil
@@ -393,6 +415,16 @@ func (c *RemoveCommand) removePrunable(ctx context.Context, branch string, opts 
 	// Prune stale worktree records
 	if _, err := c.Git.WorktreePrune(ctx); err != nil {
 		return result, fmt.Errorf("failed to prune worktrees: %w", err)
+	}
+
+	// A detached worktree holds no branch, so pruning the record is the whole job.
+	if checkResult.Detached {
+		c.Log.DebugContext(ctx, "run completed",
+			"category", LogCategoryRemove,
+			"path", checkResult.WorktreePath,
+			"detached", true,
+			"prunable", true)
+		return result, nil
 	}
 
 	// Delete the branch
@@ -614,15 +646,135 @@ func (c *RemoveCommand) Check(ctx context.Context, branch string, opts CheckOpti
 	return result, nil
 }
 
+// checkDetached checks whether a detached-HEAD worktree can be removed.
+// Such a worktree carries no branch, so removing it deletes no ref and any
+// commit already reachable from target survives it. Plain ancestry is the
+// right merge test here, unlike the first-parent test branch removal needs.
+func (c *RemoveCommand) checkDetached(ctx context.Context, wt Worktree, opts CheckOptions) (CheckResult, error) {
+	result := CheckResult{
+		Detached:     true,
+		WorktreePath: wt.Path,
+		Prunable:     wt.Prunable,
+	}
+
+	if c.Config.WorktreeSourceDir == "" {
+		return result, fmt.Errorf("worktree source directory is not configured")
+	}
+
+	c.Log.DebugContext(ctx, "checking detached",
+		"category", LogCategoryRemove,
+		"path", wt.Path,
+		"head", wt.HEAD,
+		"prunable", wt.Prunable)
+
+	// A prunable worktree has no directory left to inspect, so the state
+	// checks below cannot run and only ancestry decides.
+	if wt.Prunable {
+		if !c.isDetachedContainedIn(ctx, wt.HEAD, opts) {
+			result.SkipReason = SkipNotMerged
+			return result, nil
+		}
+		result.CanRemove = true
+		result.CleanReason = CleanMerged
+		return result, nil
+	}
+
+	changedFiles, err := c.Git.InDir(wt.Path).ChangedFiles(ctx)
+	if err != nil {
+		return result, fmt.Errorf("failed to check uncommitted changes: %w", err)
+	}
+	// Twig-managed symlinks show up as untracked in git status; exclude
+	// them so they are not mistaken for genuine uncommitted changes.
+	changedFiles, excludedSymlinks := filterSymlinkManagedFiles(c.FS, wt.Path, c.Config.Symlinks, changedFiles)
+	if len(excludedSymlinks) > 0 {
+		c.Log.DebugContext(ctx, "excluded symlink-managed paths from changed files",
+			"category", LogCategoryRemove,
+			"path", wt.Path,
+			"paths", excludedSymlinks)
+	}
+	result.ChangedFiles = changedFiles
+
+	// Submodule status affects the removal decision only when force is not
+	// elevated. Compute it once here and cache it for Run() to reuse.
+	smStatus := SubmoduleCleanStatusUnknown
+	if opts.Force < WorktreeForceLevelUnclean {
+		if s, err := c.submoduleCleanStatus(ctx, wt.Path); err == nil {
+			smStatus = s
+		}
+	}
+	result.SubmoduleStatus = smStatus
+
+	contained := c.isDetachedContainedIn(ctx, wt.HEAD, opts)
+
+	reason := c.checkWorktreeStateSkipReason(ctx, wt, opts, changedFiles, smStatus)
+	// Ancestry is the merge test for a detached worktree, and -f bypasses it
+	// exactly as it bypasses the merged check for branches.
+	if reason == "" && !contained && opts.Force < WorktreeForceLevelUnclean {
+		reason = SkipNotMerged
+	}
+
+	if reason != "" {
+		result.SkipReason = reason
+		// Uncommitted work is all a detached worktree can hold, so a contained
+		// HEAD does not make it merely stale: leaving CleanReason empty keeps
+		// --stale from bypassing the changes check, matching WIP branches.
+		if contained && reason != SkipHasChanges && reason != SkipDirtySubmodule {
+			result.CleanReason = CleanMerged
+		}
+		c.Log.DebugContext(ctx, "skip",
+			"category", LogCategoryRemove,
+			"reason", reason,
+			"cleanReason", result.CleanReason,
+			"path", wt.Path)
+		return result, nil
+	}
+
+	result.CanRemove = true
+	if contained {
+		result.CleanReason = CleanMerged
+	}
+	return result, nil
+}
+
+// isDetachedContainedIn reports whether a detached HEAD is already contained
+// in the target branch. Without a target there is nothing to compare against,
+// and an unresolvable HEAD must not read as removable, so both answer false.
+func (c *RemoveCommand) isDetachedContainedIn(ctx context.Context, head string, opts CheckOptions) bool {
+	if head == "" || opts.Target == "" {
+		return false
+	}
+	contained, err := c.Git.IsAncestor(ctx, head, opts.Target)
+	return err == nil && contained
+}
+
 // checkSkipReason checks if worktree should be skipped and returns the reason.
 // force level controls which conditions can be bypassed (matches git worktree behavior).
 // changedFiles and smStatus are pre-fetched to avoid redundant git calls.
 func (c *RemoveCommand) checkSkipReason(ctx context.Context, wt Worktree, opts CheckOptions, changedFiles []FileStatus, smStatus SubmoduleCleanStatus) SkipReason {
-	// Check detached HEAD (never bypassed)
+	// Check detached HEAD (never bypassed). Removal here is keyed by branch
+	// name, so a worktree without one has no removal path; clean reaches those
+	// through checkDetached instead.
 	if wt.Detached {
 		return SkipDetached
 	}
 
+	if reason := c.checkWorktreeStateSkipReason(ctx, wt, opts, changedFiles, smStatus); reason != "" {
+		return reason
+	}
+
+	// Check merged (only when target is specified)
+	if opts.Target != "" && opts.Force < WorktreeForceLevelUnclean {
+		return c.checkMergedSkipReason(ctx, wt.Branch, opts.Target, opts.MergeStatus)
+	}
+
+	return ""
+}
+
+// checkWorktreeStateSkipReason checks the conditions that depend on the
+// worktree's own state rather than on what its HEAD points at.
+// force level controls which conditions can be bypassed (matches git worktree behavior).
+// changedFiles and smStatus are pre-fetched to avoid redundant git calls.
+func (c *RemoveCommand) checkWorktreeStateSkipReason(ctx context.Context, wt Worktree, opts CheckOptions, changedFiles []FileStatus, smStatus SubmoduleCleanStatus) SkipReason {
 	// Check current directory (never bypassed). Compare the worktree against the
 	// resolved worktree root of cwd. A caller that checks many worktrees (clean)
 	// resolves the root once and passes it in; otherwise resolve it here. An
@@ -653,11 +805,6 @@ func (c *RemoveCommand) checkSkipReason(ctx context.Context, wt Worktree, opts C
 		if len(changedFiles) > 0 {
 			return SkipHasChanges
 		}
-	}
-
-	// Check merged (only when target is specified)
-	if opts.Target != "" && opts.Force < WorktreeForceLevelUnclean {
-		return c.checkMergedSkipReason(ctx, wt.Branch, opts.Target, opts.MergeStatus)
 	}
 
 	return ""

--- a/remove_test.go
+++ b/remove_test.go
@@ -894,8 +894,8 @@ func TestRemoveCommand_Check(t *testing.T) {
 			wantClean:     CleanUpstreamGone,
 		},
 		// Skip cases
-		// Note: Detached HEAD worktrees are handled directly in CleanCommand.Run
-		// since they have no branch name and cannot be found by WorktreeFindByBranch.
+		// Note: Check is keyed by branch name, so detached HEAD worktrees never
+		// reach these cases; they go through checkDetached instead.
 		{
 			name:   "skip_current_directory",
 			branch: "feat/a",
@@ -1327,7 +1327,8 @@ func TestRemoveCommand_Check(t *testing.T) {
 			wantCanRemove: true,
 		},
 		// Never bypassed (even with -ff)
-		// Note: Detached HEAD worktrees are handled directly in CleanCommand.Run.
+		// Note: Check is keyed by branch name, so detached HEAD worktrees never
+		// reach these cases; they go through checkDetached instead.
 		{
 			name:   "force_locked_does_not_bypass_current_dir",
 			branch: "feat/a",


### PR DESCRIPTION
## Overview

`twig clean` skipped detached HEAD worktrees unconditionally, so a
worktree sitting on a commit already contained in the target branch
could never be cleaned. It stayed in the list forever with a
`detached HEAD` skip reason.

This makes such worktrees cleanup candidates when their HEAD is
already contained in the target branch.

## Detection logic

A detached worktree owns no branch, so removing it deletes no ref:
every commit it held stays reachable from the target. That makes plain
reachability the right merge test:

```txt
git merge-base --is-ancestor COMMIT TARGET
```

This is deliberately **not** shared with the branch path. For branches,
`IsFirstParentAncestor` exists to avoid treating a commit reachable only
through a merge commit's second parent as WIP. That distinction matters
because branch removal deletes a ref; here nothing is deleted, so plain
ancestry is both sufficient and safe. The new `GitRunner.IsAncestor`
is documented as such, and exit code 1 (git's "not an ancestor" answer)
is separated from real failures, which propagate as errors.

Removal reuses `RemoveCommand.Run` with the branch deletion step
skipped, since there is no branch to delete.

## Safety checks

All existing checks are unchanged for detached worktrees: uncommitted
changes, dirty submodules, locked, current directory, main worktree.
Symlink-managed files are excluded from the changes check exactly as
for branches.

Two interactions worth calling out:

- **`--stale` does not apply.** A detached HEAD contained in the target
  has no commits of its own, so uncommitted changes are the only work it
  can hold. That is the same situation the existing WIP branch
  protection guards, so it is kept. Implemented by leaving `CleanReason`
  empty when the skip reason is uncommitted changes or a dirty
  submodule, which the existing stale loop already honors.
- **`-f` bypasses the reachability test**, mirroring how it bypasses
  "not merged" for branches. This is a behavior change: previously
  `clean -f` never touched detached worktrees, and now it removes every
  detached worktree that passes the remaining checks, including ones
  holding commits nothing else references. Documented in the Force
  section.

Prunable detached worktrees (directory deleted externally) are handled
by pruning the stale record only.

## Output

Detached candidates are identified by path, since they have no branch
name:

```txt
clean:
  /path/to/worktree/experiment (detached, merged)

skip:
  /path/to/worktree/spike
    ✗ not merged
```

Removal reports `Removed worktree: PATH` instead of
`Removed worktree and branch: BRANCH`.

## Incidental fix

Detached worktrees were appended to the shared `candidates` slice from
the main loop without holding the mutex, while checks launched in
earlier iterations appended under it. Routing detached worktrees through
the same parallel check phase removes that unsynchronized append.

## Verification

- `go test ./...` and `go test -tags=integration ./...` both pass.
- Unit tests: ancestry check (`IsAncestor`, including non-1 exit codes
  propagating as errors), candidate classification, `--stale` not
  overriding, branch deletion not called, and output formatting.
  The mock executor gained an explicit `merge-base` handler that
  reports non-ancestry unless declared, so ancestry cannot be assumed
  by accident in tests.
- Integration tests: cleaning a contained detached worktree (asserting
  no branch is deleted), skipping one with its own commits, `-f`
  removing it anyway, skipping on changes / `--stale` / locked /
  current directory, and pruning a deleted detached worktree.
- Manual run with `out/twig` on a scratch repo: a detached worktree at
  an ancestor commit is listed as `(detached, merged)` and removed with
  branches left untouched; a detached worktree with its own commit is
  skipped as `not merged`; a dirty ancestor worktree stays skipped
  under `--stale`.
- `go test -race` passes for the clean, remove, and git tests under
  `-count=8`, covering the parallel check path this change touches.

## Pre-existing issues observed, not addressed here

Both were reproduced on `main` without these changes, so they are out
of scope for this PR and noted only so they are not mistaken for
regressions:

- `TestCleanCommand_Integration/ForceUncleanBypassesNotMerged` is
  flaky under load (reproduced on `main` in 2 of 4 stress runs with
  `-count=15`). The removal phase runs `git worktree prune` for a
  prunable candidate concurrently with `git worktree remove` for
  another in the same repository; when prune loses that race the
  branch is never deleted.
- `go test -race` reports a data race between `TestSetColorMode` and
  `TestIsColorEnabled` over the package-level color mode, which both
  parallel tests mutate.

https://claude.ai/code/session_01SPnVkuzvTEVM8GtByWvqdE
